### PR TITLE
feat(wezterm): Add Spotify integration plugin

### DIFF
--- a/.config/wezterm/SPOTIFY_PLUGIN_README.md
+++ b/.config/wezterm/SPOTIFY_PLUGIN_README.md
@@ -1,0 +1,98 @@
+# WezTerm Spotify Plugin
+
+WezTerm のステータスバーに Spotify の再生情報を表示し、キーボードショートカットで Spotify を制御できるプラグインです。
+
+## 機能
+
+### ステータスバー表示
+
+- 現在再生中の楽曲名とアーティスト名を表示
+- 再生/一時停止状態をアイコンで表示
+- Spotify 公式の緑色（再生中）とグレー（一時停止中）で色分け
+
+### キーボードショートカット
+
+以下のキーボードショートカットで Spotify を制御できます：
+
+- `Cmd+Shift+S`: 再生/一時停止の切り替え
+- `Cmd+Shift+N`: 次の曲
+- `Cmd+Shift+P`: 前の曲
+- `Cmd+Shift+I`: 現在の楽曲情報を通知で表示
+- `Cmd+Shift+=`: 音量を上げる
+- `Cmd+Shift+-`: 音量を下げる
+
+## 必要条件
+
+- macOS（AppleScript を使用して Spotify を制御）
+- Spotify アプリケーション
+- WezTerm
+
+## ファイル構成
+
+- `spotify.lua`: Spotify 情報取得とキャッシュ機能
+- `spotify-controls.lua`: Spotify コントロール機能
+- `status.lua`: ステータスバー統合（更新済み）
+- `keybinds.lua`: キーバインド設定（更新済み）
+- `colors.lua`: Spotify 用の色定義（更新済み）
+
+## 設定の詳細
+
+### キャッシュ機能
+
+- Spotify 情報は 5 秒間キャッシュされ、AppleScript の実行頻度を抑制
+- 楽曲名が長い場合は自動的に省略表示
+
+### エラーハンドリング
+
+- Spotify が起動していない場合は何も表示しない
+- AppleScript 実行エラーは自動的に処理される
+
+## カスタマイズ
+
+### 表示テキストの長さ制限
+
+`spotify.lua`の`format_track_display`関数で調整可能：
+
+```lua
+local function format_track_display(track, artist, max_length)
+  max_length = max_length or 30 -- この値を変更
+  -- ...
+end
+```
+
+### キャッシュ時間
+
+`spotify.lua`の`CACHE_DURATION`変数で調整可能：
+
+```lua
+local CACHE_DURATION = 5000 -- ミリ秒単位（5秒）
+```
+
+### 色の変更
+
+`colors.lua`で Spotify 用の色を変更可能：
+
+```lua
+SPOTIFY_GREEN = { Color = "#1DB954" }, -- 再生中の色
+SPOTIFY_GRAY = { Color = "#B3B3B3" },  -- 一時停止中の色
+```
+
+## トラブルシューティング
+
+1. **Spotify の情報が表示されない**
+
+   - Spotify アプリが起動していることを確認
+   - macOS のプライバシー設定で WezTerm に AppleScript の実行許可が与えられていることを確認
+
+2. **キーボードショートカットが動作しない**
+
+   - 他のアプリケーションと競合していないか確認
+   - WezTerm がアクティブな状態で実行していることを確認
+
+3. **パフォーマンスの問題**
+   - キャッシュ時間を長くする（`CACHE_DURATION`を増加）
+   - 表示テキストの長さ制限を短くする
+
+## 更新履歴
+
+- 初回リリース: Spotify 情報表示とキーボードコントロール機能

--- a/.config/wezterm/colors.lua
+++ b/.config/wezterm/colors.lua
@@ -5,4 +5,6 @@ return {
   YELLOW = { Color = "#dfe166" },
   TOKYO_NIGHT_BLUE = { Color = "#5AC9FB" },
   TOKYO_NIGHT_GREEN = { Color = "#8FC668" },
+  SPOTIFY_GREEN = { Color = "#1DB954" },
+  SPOTIFY_GRAY = { Color = "#B3B3B3" },
 }

--- a/.config/wezterm/keybinds.lua
+++ b/.config/wezterm/keybinds.lua
@@ -1,5 +1,6 @@
 local wezterm = require("wezterm")
 local act = wezterm.action
+local spotify_controls = require("spotify-controls")
 
 return {
   keys = {
@@ -162,6 +163,14 @@ return {
     { key = "DownArrow", mods = "SHIFT|ALT|CTRL", action = act.AdjustPaneSize({ "Down", 1 }) },
     { key = "Copy", mods = "NONE", action = act.CopyTo("Clipboard") },
     { key = "Paste", mods = "NONE", action = act.PasteFrom("Clipboard") },
+
+    -- Spotify controls (Cmd+Shift+S prefix)
+    { key = "s", mods = "CMD|SHIFT", action = wezterm.action_callback(spotify_controls.play_pause) },
+    { key = "n", mods = "CMD|SHIFT", action = wezterm.action_callback(spotify_controls.next_track) },
+    { key = "p", mods = "CMD|SHIFT", action = wezterm.action_callback(spotify_controls.previous_track) },
+    { key = "i", mods = "CMD|SHIFT", action = wezterm.action_callback(spotify_controls.show_track_info) },
+    { key = "=", mods = "CMD|SHIFT", action = wezterm.action_callback(spotify_controls.volume_up) },
+    { key = "-", mods = "CMD|SHIFT", action = wezterm.action_callback(spotify_controls.volume_down) },
   },
   key_tables = {
     copy_mode = {

--- a/.config/wezterm/spotify-controls.lua
+++ b/.config/wezterm/spotify-controls.lua
@@ -1,0 +1,68 @@
+local wezterm = require("wezterm")
+
+local M = {}
+
+-- Spotify control functions
+function M.play_pause()
+  wezterm.run_child_process({
+    "osascript",
+    "-e",
+    'tell application "Spotify" to playpause'
+  })
+end
+
+function M.next_track()
+  wezterm.run_child_process({
+    "osascript",
+    "-e",
+    'tell application "Spotify" to next track'
+  })
+end
+
+function M.previous_track()
+  wezterm.run_child_process({
+    "osascript",
+    "-e",
+    'tell application "Spotify" to previous track'
+  })
+end
+
+function M.volume_up()
+  wezterm.run_child_process({
+    "osascript",
+    "-e",
+    'tell application "Spotify" to set sound volume to (sound volume + 10)'
+  })
+end
+
+function M.volume_down()
+  wezterm.run_child_process({
+    "osascript",
+    "-e",
+    'tell application "Spotify" to set sound volume to (sound volume - 10)'
+  })
+end
+
+-- Show current track information
+function M.show_track_info()
+  local spotify = require("spotify")
+  local info = spotify.get_spotify_info()
+
+  if info then
+    local status = info.is_playing and "Playing" or "Paused"
+    local message = string.format("%s: %s - %s", status, info.track, info.artist)
+
+    -- Get the current window and show notification
+    local window = wezterm.mux.get_active_window()
+    if window then
+      window:toast_notification("Spotify", message, nil, 3000)
+    end
+  else
+    local window = wezterm.mux.get_active_window()
+    if window then
+      window:toast_notification("Spotify", "Spotify is not running", nil, 2000)
+    end
+  end
+end
+
+return M

--- a/.config/wezterm/spotify.lua
+++ b/.config/wezterm/spotify.lua
@@ -1,0 +1,142 @@
+local wezterm = require("wezterm")
+
+local M = {}
+
+-- Spotify information cache
+local spotify_cache = {
+  last_update = 0,
+  track = "",
+  artist = "",
+  is_playing = false,
+  is_available = false,
+}
+
+-- Cache duration in milliseconds
+local CACHE_DURATION = 5000 -- 5 seconds
+
+-- Get Spotify status using AppleScript (macOS only)
+local function get_spotify_status()
+  local current_time = wezterm.time.now() * 1000
+
+  -- Return cached data if still valid
+  if current_time - spotify_cache.last_update < CACHE_DURATION then
+    return spotify_cache
+  end
+
+  local success, result = pcall(function()
+    -- Check if Spotify is running
+    local spotify_running = wezterm.run_child_process({
+      "osascript",
+      "-e",
+      'tell application "System Events" to (name of processes) contains "Spotify"'
+    })
+
+    if not spotify_running.stdout or spotify_running.stdout:match("false") then
+      spotify_cache.is_available = false
+      spotify_cache.last_update = current_time
+      return spotify_cache
+    end
+
+    -- Get current track information
+    local track_info = wezterm.run_child_process({
+      "osascript",
+      "-e",
+      [[
+        tell application "Spotify"
+          if player state is playing then
+            set trackName to name of current track
+            set artistName to artist of current track
+            return trackName & " by " & artistName & "|playing"
+          else if player state is paused then
+            set trackName to name of current track
+            set artistName to artist of current track
+            return trackName & " by " & artistName & "|paused"
+          else
+            return "No track|stopped"
+          end if
+        end tell
+      ]]
+    })
+
+    if track_info.stdout then
+      local output = track_info.stdout:gsub("\n", "")
+      local track_artist, state = output:match("(.+)|(.+)")
+
+      if track_artist and state then
+        local track, artist = track_artist:match("(.+) by (.+)")
+
+        spotify_cache.track = track or "Unknown Track"
+        spotify_cache.artist = artist or "Unknown Artist"
+        spotify_cache.is_playing = (state == "playing")
+        spotify_cache.is_available = true
+      else
+        spotify_cache.is_available = false
+      end
+    else
+      spotify_cache.is_available = false
+    end
+
+    spotify_cache.last_update = current_time
+    return spotify_cache
+  end)
+
+  if not success then
+    spotify_cache.is_available = false
+    spotify_cache.last_update = current_time
+  end
+
+  return spotify_cache
+end
+
+-- Format track name for display (truncate if too long)
+local function format_track_display(track, artist, max_length)
+  max_length = max_length or 30
+  local full_text = track .. " - " .. artist
+
+  if #full_text <= max_length then
+    return full_text
+  end
+
+  -- Try truncating artist first
+  local truncated = track .. " - " .. artist:sub(1, max_length - #track - 5) .. "..."
+  if #truncated <= max_length then
+    return truncated
+  end
+
+  -- Truncate track if still too long
+  return track:sub(1, max_length - 3) .. "..."
+end
+
+-- Get Spotify display information
+function M.get_spotify_info()
+  local status = get_spotify_status()
+
+  if not status.is_available then
+    return nil
+  end
+
+  return {
+    track = status.track,
+    artist = status.artist,
+    is_playing = status.is_playing,
+    display_text = format_track_display(status.track, status.artist),
+    icon = status.is_playing and "󰐊" or "󰏤" -- Play or pause icon
+  }
+end
+
+-- Get Spotify status for status bar
+function M.get_status_element()
+  local info = M.get_spotify_info()
+
+  if not info then
+    return nil
+  end
+
+  return {
+    icon = info.icon,
+    text = info.display_text,
+    color = info.is_playing and "#1DB954" or "#B3B3B3" -- Spotify green or gray
+  }
+end
+
+return M

--- a/.config/wezterm/status.lua
+++ b/.config/wezterm/status.lua
@@ -1,5 +1,6 @@
 local wezterm = require("wezterm")
 local colors = require("colors")
+local spotify = require("spotify")
 
 local DEFAULT_FG = colors.DEFAULT_FG
 local DEFAULT_BG = colors.DEFAULT_BG
@@ -41,6 +42,16 @@ end
 -- Right
 local function UpdateRight(window, pane)
   local elems = {}
+
+  -- Spotify status
+  local spotify_info = spotify.get_status_element()
+  if spotify_info then
+    AddElement(
+      elems,
+      { Foreground = { Color = spotify_info.color }, Text = spotify_info.icon },
+      spotify_info.text
+    )
+  end
 
   -- DateTime
   AddElement(


### PR DESCRIPTION
## 🎵 WezTerm Spotify Plugin

This PR adds a comprehensive Spotify integration plugin for WezTerm with status bar display and keyboard controls.

### ✨ Features

#### Status Bar Integration
- 🎵 Real-time display of currently playing track and artist
- ▶️ Visual indicators for play/pause state with icons
- 🎨 Spotify brand colors (green for playing, gray for paused)
- ⚡ Optimized with 5-second caching to reduce AppleScript calls

#### Keyboard Controls
- `Cmd+Shift+S`: Play/pause toggle
- `Cmd+Shift+N`: Next track
- `Cmd+Shift+P`: Previous track  
- `Cmd+Shift+I`: Show track info notification
- `Cmd+Shift+=`: Volume up
- `Cmd+Shift+-`: Volume down

### 📁 Files Added
- `spotify.lua`: Core Spotify integration with caching
- `spotify-controls.lua`: Keyboard control functions
- `SPOTIFY_PLUGIN_README.md`: Complete documentation

### 🔧 Files Modified  
- `status.lua`: Added Spotify status display
- `keybinds.lua`: Added Spotify control keybindings
- `colors.lua`: Added Spotify brand colors

### 🖥️ Requirements
- macOS (uses AppleScript for Spotify control)
- Spotify application
- WezTerm

### 🚀 Usage
1. Restart WezTerm
2. Launch Spotify and play music
3. See track info in status bar
4. Use keyboard shortcuts for control

### 📖 Documentation
Complete setup and customization instructions are included in `SPOTIFY_PLUGIN_README.md`.

### 🛠️ Technical Details
- Intelligent caching prevents excessive AppleScript execution
- Graceful error handling when Spotify is not running  
- Automatic text truncation for long track names
- Non-blocking background processes for smooth UX