### PR TITLE
feat(nix): migrate starship Tokyo Night theme to nix configuration

### DIFF
--- a/nix/hosts/darwin-min/home.nix
+++ b/nix/hosts/darwin-min/home.nix
@@ -20,11 +20,13 @@ in
   home = {
     stateVersion = "25.05";
 
-    file = import ../../modules/symlinks.nix {
-      inherit config dotfilesPath;
-    } // {
+    file =
+      import ../../modules/symlinks.nix {
+        inherit config dotfilesPath;
+      }
+      // {
 
-    };
+      };
   };
 
   programs.home-manager.enable = true;

--- a/nix/hosts/darwin/home.nix
+++ b/nix/hosts/darwin/home.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 let
   username = "siraken";
   dotfilesPath = "${config.home.homeDirectory}/dotfiles";
@@ -23,18 +28,25 @@ in
     # sessionVariables = import ../../modules/variable.nix;
     # sessionPath = import ../../modules/path.nix;
 
-    file = import ../../modules/home-symlinks.nix {
-      inherit config dotfilesPath;
-    } // {
+    file =
+      import ../../modules/home-symlinks.nix {
+        inherit config dotfilesPath;
+      }
+      // {
 
-    };
+      };
 
     shell = {
       enableShellIntegration = true;
     };
 
     activation = import ../../modules/home-activation.nix {
-      inherit config pkgs lib dotfilesPath;
+      inherit
+        config
+        pkgs
+        lib
+        dotfilesPath
+        ;
     };
   };
 

--- a/nix/hosts/minimal/home.nix
+++ b/nix/hosts/minimal/home.nix
@@ -22,11 +22,13 @@ in
   home = {
     stateVersion = "25.05";
 
-    file = import ../../modules/symlinks.nix {
-      inherit config dotfilesPath;
-    } // {
+    file =
+      import ../../modules/symlinks.nix {
+        inherit config dotfilesPath;
+      }
+      // {
 
-    };
+      };
 
     packages = [
       pkgs.eza

--- a/nix/hosts/wsl-ubuntu/home.nix
+++ b/nix/hosts/wsl-ubuntu/home.nix
@@ -27,11 +27,13 @@ in
   home = {
     stateVersion = "25.05";
 
-    file = import ../../modules/symlinks.nix {
-      inherit config dotfilesPath;
-    } // {
+    file =
+      import ../../modules/symlinks.nix {
+        inherit config dotfilesPath;
+      }
+      // {
 
-    };
+      };
 
     packages = [
       pkgs.eza

--- a/nix/modules/home-activation.nix
+++ b/nix/modules/home-activation.nix
@@ -1,6 +1,11 @@
-{ config, pkgs, lib, dotfilesPath }:
 {
-  createSymlinksForAgents = lib.hm.dag.entryAfter ["writeBoundary"] ''
+  config,
+  pkgs,
+  lib,
+  dotfilesPath,
+}:
+{
+  createSymlinksForAgents = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash ${dotfilesPath}/symlink
   '';
 }

--- a/nix/modules/path.nix
+++ b/nix/modules/path.nix
@@ -1,4 +1,5 @@
-{}: [
+{ }:
+[
   "/opt/homebrew/opt/openssl@3/bin" # Use openssl installed by homebrew
   "/opt/homebrew/sbin"
   "/opt/homebrew/bin"

--- a/nix/modules/variable.nix
+++ b/nix/modules/variable.nix
@@ -1,4 +1,5 @@
-{}: {
+{ }:
+{
   "XDG_CONFIG_HOME" = "$HOME/.config";
   "SSH_AUTH_SOCK" = "$HOME/.1password/agent.sock";
   "GOPATH" = "$HOME/go";

--- a/nix/programs/starship.nix
+++ b/nix/programs/starship.nix
@@ -3,9 +3,79 @@
   programs.starship = {
     enable = true;
     settings = {
+      "$schema" = "https://starship.rs/config-schema.json";
+
+      format = ''
+        $os[](bg:v_secondary fg:v_primary)$directory[ ](bg:v_base fg:v_secondary)$git_branch$git_status[](fg:v_base)
+        $character'';
+
+      right_format = "$localip";
+
+      palette = "tokyo-night";
+
+      palettes.tokyo-night = {
+        git-green = "#6CA53A";
+        v_base = "#202334";
+        v_primary = "#83A1F1";
+        v_secondary = "#3D425F";
+        v_tertiary = "#3D4A6D";
+        t_base = "#769ff0";
+        t_primary = "#1E202E";
+        t_secondary = "#7892DA";
+        t_tertiary = "#D9DBE3";
+      };
+
       add_newline = true;
       command_timeout = 500;
       scan_timeout = 30;
+
+      os = {
+        disabled = false;
+        format = "[  $symbol  ](bg:v_primary fg:t_primary)";
+        symbols = {
+          Arch = "";
+          CentOS = "";
+          Debian = "";
+          Fedora = "";
+          FreeBSD = "";
+          Gentoo = "";
+          Linux = "";
+          Macos = "";
+          Mint = "";
+          NixOS = "";
+          Ubuntu = "";
+          Unknown = "";
+          Windows = "";
+        };
+      };
+
+      localip = {
+        ssh_only = true;
+        format = "[ $localipv4 ](bg:v_primary fg:t_primary bold)";
+        disabled = false;
+      };
+
+      directory = {
+        format = "[  $path ](bg:v_secondary fg:t_secondary)";
+        truncation_length = 3;
+        truncation_symbol = "…/";
+        substitutions = {
+          Documents = "󰈙 ";
+          Downloads = " ";
+          Music = "󰝚 ";
+          Pictures = " ";
+        };
+      };
+
+      git_branch = {
+        symbol = "";
+        format = "[[$symbol $branch ](fg:git-green bg:v_base bold)](bg:v_base)";
+      };
+
+      git_status = {
+        format = "[[($all_status$ahead_behind )](fg:t_base bg:v_base)](bg:v_base$style)";
+      };
+
       aws = {
         disabled = true;
       };

--- a/nix/programs/yazi.nix
+++ b/nix/programs/yazi.nix
@@ -7,13 +7,23 @@
     enableFishIntegration = true;
     settings = {
       mgr = {
-        ratio = [2 3 3];
+        ratio = [
+          2
+          3
+          3
+        ];
         sort_by = "none";
         sort_sensitive = false;
         sort_reverse = false;
         sort_dir_first = true;
         show_symlink = true;
-        mouse_events = ["click" "scroll" "touch" "move" "drag"];
+        mouse_events = [
+          "click"
+          "scroll"
+          "touch"
+          "move"
+          "drag"
+        ];
       };
     };
   };


### PR DESCRIPTION
## Summary

- Migrate starship Tokyo Night powerline theme from external TOML file to Nix declarative configuration
- This is the first step in the migration plan outlined in #8

## Changes

- **Added to `nix/programs/starship.nix`**:
  - Tokyo Night color palette definition
  - Custom format with OS, directory, git branch/status, and localip modules
  - Icon mappings for various Linux distributions and macOS
  - Directory substitutions for common folders

- **Side effects**:
  - Format related Nix files with nixfmt (home-activation.nix, path.nix, variable.nix, yazi.nix)

## Benefits

- ✅ Declarative configuration management
- ✅ Version controlled in Nix
- ✅ Consistent across multiple machines
- ✅ Easy rollback with Nix generations

## Testing

- [x] Build successful with `darwin-rebuild build`
- [x] Configuration applied with `darwin-rebuild switch`
- [x] Verified `~/.config/starship.toml` is correctly symlinked to Nix store
- [x] Theme rendering works as expected

## Migration Progress

Relates to #8 - Nix home-manager migration plan

**Completed**: starship (難易度: 易)

**Next candidates**: claude settings, gemini settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)