### PR TITLE
feat(alacritty): migrate configuration to Nix

### DIFF
--- a/nix/hosts/darwin/home.nix
+++ b/nix/hosts/darwin/home.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 let
   username = "siraken";
   dotfilesPath = "${config.home.homeDirectory}/dotfiles";
@@ -7,6 +12,7 @@ in
   imports = [
     # ../../environment/system-packages.nix
     # ../../programs/bash.nix
+    ../../programs/alacritty.nix
     ../../programs/git.nix
     ../../programs/zsh.nix
     ../../programs/zoxide.nix
@@ -23,18 +29,25 @@ in
     # sessionVariables = import ../../modules/variable.nix;
     # sessionPath = import ../../modules/path.nix;
 
-    file = import ../../modules/home-symlinks.nix {
-      inherit config dotfilesPath;
-    } // {
+    file =
+      import ../../modules/home-symlinks.nix {
+        inherit config dotfilesPath;
+      }
+      // {
 
-    };
+      };
 
     shell = {
       enableShellIntegration = true;
     };
 
     activation = import ../../modules/home-activation.nix {
-      inherit config pkgs lib dotfilesPath;
+      inherit
+        config
+        pkgs
+        lib
+        dotfilesPath
+        ;
     };
   };
 

--- a/nix/modules/home-symlinks.nix
+++ b/nix/modules/home-symlinks.nix
@@ -32,7 +32,7 @@
   ".config/neovide".source = "${dotfilesPath}/.config/neovide";
   ".config/helix".source = "${dotfilesPath}/.config/helix";
   ".config/kak".source = "${dotfilesPath}/.config/kak";
-  ".config/alacritty".source = "${dotfilesPath}/.config/alacritty";
+  # ".config/alacritty".source = "${dotfilesPath}/.config/alacritty"; # Managed by nix/programs/alacritty.nix
   ".config/wezterm".source = "${dotfilesPath}/.config/wezterm";
   ".config/ghostty".source = "${dotfilesPath}/.config/ghostty";
   ".config/yt-dlp".source = "${dotfilesPath}/.config/yt-dlp";

--- a/nix/programs/alacritty.nix
+++ b/nix/programs/alacritty.nix
@@ -1,0 +1,145 @@
+{ pkgs, ... }:
+{
+  programs.alacritty = {
+    enable = true;
+
+    settings = {
+      # General settings
+      live_config_reload = true;
+
+      # Environment variables
+      env = {
+        GITHUB_USERNAME = "siraken";
+        TERM = "xterm-256color";
+      };
+
+      # Terminal settings
+      terminal = {
+        shell = {
+          program = "/opt/homebrew/bin/bash";
+        };
+      };
+
+      # Cursor settings
+      cursor = {
+        style = {
+          blinking = "Off";
+          shape = "Block";
+        };
+      };
+
+      # Mouse settings
+      mouse = {
+        hide_when_typing = false;
+      };
+
+      # Scrolling settings
+      scrolling = {
+        history = 10000;
+      };
+
+      # Keyboard settings
+      keyboard = {
+        bindings = [ ];
+      };
+
+      # Debug settings
+      debug = {
+        render_timer = false;
+        persistent_logging = false;
+        log_level = "Warn";
+        renderer = "None";
+        print_events = false;
+        highlight_damage = false;
+        prefer_egl = false;
+      };
+
+      # Window settings
+      window = {
+        dynamic_padding = true;
+        dynamic_title = true;
+        opacity = 0.5;
+        startup_mode = "Windowed";
+        title = "Alacritty";
+        blur = true;
+        decorations = "Buttonless";
+
+        class = {
+          general = "Alacritty";
+          instance = "Alacritty";
+        };
+
+        dimensions = {
+          columns = 150;
+          lines = 40;
+        };
+      };
+
+      # Font settings
+      font = {
+        builtin_box_drawing = true;
+        size = 16.0;
+
+        normal = {
+          family = "Hack Nerd Font";
+          style = "Regular";
+        };
+
+        bold = {
+          family = "Hack Nerd Font";
+          style = "Bold";
+        };
+
+        italic = {
+          family = "Hack Nerd Font";
+          style = "Italic";
+        };
+
+        bold_italic = {
+          family = "Hack Nerd Font";
+          style = "Bold Italic";
+        };
+
+        glyph_offset = {
+          x = 0;
+          y = 0;
+        };
+
+        offset = {
+          x = 1;
+          y = 0;
+        };
+      };
+
+      # Colors (Tokyo Night)
+      colors = {
+        primary = {
+          background = "#1a1b26";
+          foreground = "#a9b1d6";
+        };
+
+        normal = {
+          black = "#32344a";
+          red = "#f7768e";
+          green = "#9ece6a";
+          yellow = "#e0af68";
+          blue = "#7aa2f7";
+          magenta = "#ad8ee6";
+          cyan = "#449dab";
+          white = "#787c99";
+        };
+
+        bright = {
+          black = "#444b6a";
+          red = "#ff7a93";
+          green = "#b9f27c";
+          yellow = "#ff9e64";
+          blue = "#7da6ff";
+          magenta = "#bb9af7";
+          cyan = "#0db9d7";
+          white = "#acb0d0";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Migrate Alacritty configuration from TOML files to Nix declarative configuration
- Create `nix/programs/alacritty.nix` with complete settings migration
- Remove symlink management for Alacritty (now handled by home-manager)

## Changes
- **Added**: `nix/programs/alacritty.nix` - Full Alacritty configuration including:
  - General settings (live config reload)
  - Environment variables (GITHUB_USERNAME, TERM)
  - Terminal, cursor, mouse, scrolling settings
  - Window configuration (opacity, blur, dimensions)
  - Font settings (Hack Nerd Font, size 16)
  - Tokyo Night color scheme
- **Modified**: `nix/hosts/darwin/home.nix` - Import alacritty.nix module
- **Modified**: `nix/modules/home-symlinks.nix` - Comment out alacritty symlink (managed by Nix)

## Test plan
- [ ] Run `darwin-rebuild switch --flake .#darwin --impure`
- [ ] Verify Alacritty configuration is applied correctly
- [ ] Check that all settings (fonts, colors, window properties) work as expected
- [ ] Confirm no conflicts with existing TOML files

🤖 Generated with [Claude Code](https://claude.com/claude-code)