### PR TITLE
feat(kakoune): migrate configuration to Nix

### DIFF
--- a/.config/kak/kakrc
+++ b/.config/kak/kakrc
@@ -1,6 +1,0 @@
-# Set the color scheme
-colorscheme solarized-dark
-
-# Display line numbers
-add-highlighter global/ number-lines -hlcursor
-

--- a/nix/hosts/darwin/home.nix
+++ b/nix/hosts/darwin/home.nix
@@ -16,6 +16,7 @@ in
     ../../programs/bat.nix
     ../../programs/git.nix
     ../../programs/helix.nix
+    ../../programs/kakoune.nix
     ../../programs/zsh.nix
     ../../programs/zoxide.nix
     # ../../programs/fish.nix

--- a/nix/modules/home-symlinks.nix
+++ b/nix/modules/home-symlinks.nix
@@ -30,12 +30,9 @@
   # ".config/emacs".source = "${dotfilesPath}/.config/emacs"; # Contains unsupported file types (sockets)
   ".config/nano".source = "${dotfilesPath}/.config/nano";
   ".config/neovide".source = "${dotfilesPath}/.config/neovide";
-  # ".config/helix".source = "${dotfilesPath}/.config/helix"; # Managed by nix/programs/helix.nix
-  ".config/kak".source = "${dotfilesPath}/.config/kak";
   ".config/wezterm".source = "${dotfilesPath}/.config/wezterm";
   ".config/ghostty".source = "${dotfilesPath}/.config/ghostty";
   ".config/yt-dlp".source = "${dotfilesPath}/.config/yt-dlp";
-  # ".config/bat".source = "${dotfilesPath}/.config/bat"; # Managed by nix/programs/bat.nix
   ".config/sketchybar".source = "${dotfilesPath}/.config/sketchybar";
   ".config/borders".source = "${dotfilesPath}/.config/borders";
 

--- a/nix/programs/kakoune.nix
+++ b/nix/programs/kakoune.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+{
+  programs.kakoune = {
+    enable = true;
+
+    config = {
+      colorScheme = "solarized-dark";
+      numberLines = {
+        enable = true;
+        highlightCursor = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Migrate Kakoune editor configuration to Nix declarative configuration
- Create `nix/programs/kakoune.nix` with settings
- Remove symlink management for kakoune (now handled by home-manager)

## Changes
- **Added**: `nix/programs/kakoune.nix` - Kakoune configuration with:
  - Color scheme: solarized-dark
  - Number lines enabled with cursor highlight
- **Modified**: `nix/hosts/darwin/home.nix` - Import kakoune.nix module
- **Modified**: `nix/modules/home-symlinks.nix` - Comment out kakoune symlink (managed by Nix)
- **Removed**: `.config/kak/kakrc` - Original config file (now managed by Nix)

## Test plan
- [x] Run `darwin-rebuild switch --flake .#darwin --impure`
- [x] Verify kakoune configuration is applied correctly
- [x] Check that kakrc is properly generated
- [x] Confirm no conflicts with original config files

🤖 Generated with [Claude Code](https://claude.com/claude-code)