### PR TITLE
feat(yt-dlp): migrate configuration to Nix

### DIFF
--- a/.config/yt-dlp/config
+++ b/.config/yt-dlp/config
@@ -1,1 +1,0 @@
---cookies-from-browser vivaldi

--- a/nix/hosts/darwin/home.nix
+++ b/nix/hosts/darwin/home.nix
@@ -23,6 +23,7 @@ in
     # ../../programs/fish.nix
     ../../programs/tmux.nix
     ../../programs/yazi.nix
+    ../../programs/yt-dlp.nix
     ../../programs/direnv.nix
     ../../programs/starship.nix
   ];

--- a/nix/modules/home-symlinks.nix
+++ b/nix/modules/home-symlinks.nix
@@ -31,7 +31,6 @@
   ".config/neovide".source = "${dotfilesPath}/.config/neovide";
   ".config/wezterm".source = "${dotfilesPath}/.config/wezterm";
   ".config/ghostty".source = "${dotfilesPath}/.config/ghostty";
-  ".config/yt-dlp".source = "${dotfilesPath}/.config/yt-dlp";
   ".config/sketchybar".source = "${dotfilesPath}/.config/sketchybar";
   ".config/borders".source = "${dotfilesPath}/.config/borders";
 

--- a/nix/programs/yt-dlp.nix
+++ b/nix/programs/yt-dlp.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+{
+  programs.yt-dlp = {
+    enable = true;
+
+    settings = {
+      cookies-from-browser = "vivaldi";
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Migrate yt-dlp configuration from dotfiles to Nix declarative management
- Create `nix/programs/yt-dlp.nix` with cookies-from-browser setting
- Update home.nix to import yt-dlp.nix
- Remove yt-dlp symlink from home-symlinks.nix

## Test plan
- [x] Build with `./flake` succeeded
- [x] Generated config file matches original settings
- [x] Original config directory removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)