### PR TITLE
feat(neovide): migrate configuration to Nix

### DIFF
--- a/.config/neovide/config.toml
+++ b/.config/neovide/config.toml
@@ -1,9 +1,0 @@
-vsync = true
-maximized = false
-frame = "full"
-title-hidden = true
-tabs = true
-
-[font]
-normal = ["Hack Nerd Font"]
-size = 16

--- a/nix/hosts/darwin/home.nix
+++ b/nix/hosts/darwin/home.nix
@@ -18,6 +18,7 @@ in
     ../../programs/helix.nix
     ../../programs/kakoune.nix
     ../../programs/kitty.nix
+    ../../programs/neovide.nix
     ../../programs/zsh.nix
     ../../programs/zoxide.nix
     # ../../programs/fish.nix

--- a/nix/modules/home-symlinks.nix
+++ b/nix/modules/home-symlinks.nix
@@ -28,7 +28,6 @@
   ".config/git/hooks".source = "${dotfilesPath}/.config/git/hooks";
   # ".config/emacs".source = "${dotfilesPath}/.config/emacs"; # Contains unsupported file types (sockets)
   ".config/nano".source = "${dotfilesPath}/.config/nano";
-  ".config/neovide".source = "${dotfilesPath}/.config/neovide";
   ".config/wezterm".source = "${dotfilesPath}/.config/wezterm";
   ".config/ghostty".source = "${dotfilesPath}/.config/ghostty";
   ".config/sketchybar".source = "${dotfilesPath}/.config/sketchybar";

--- a/nix/programs/neovide.nix
+++ b/nix/programs/neovide.nix
@@ -1,0 +1,19 @@
+{ pkgs, ... }:
+{
+  programs.neovide = {
+    enable = true;
+
+    settings = {
+      vsync = true;
+      maximized = false;
+      frame = "full";
+      title-hidden = true;
+      tabs = true;
+
+      font = {
+        normal = [ "Hack Nerd Font" ];
+        size = 16;
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Migrate neovide configuration from dotfiles to Nix declarative management
- Create `nix/programs/neovide.nix` with all settings
- Update home.nix to import neovide.nix
- Remove neovide symlink from home-symlinks.nix

## Test plan
- [x] Build with `./flake` succeeded
- [x] Generated config file matches original settings
- [x] Original config directory removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)