### PR TITLE
feat(nix): add lazygit and lazydocker programs

### DIFF
--- a/nix/hosts/darwin/home.nix
+++ b/nix/hosts/darwin/home.nix
@@ -18,6 +18,8 @@ in
     ../../programs/helix.nix
     ../../programs/kakoune.nix
     ../../programs/kitty.nix
+    ../../programs/lazydocker.nix
+    ../../programs/lazygit.nix
     ../../programs/neovide.nix
     ../../programs/zsh.nix
     ../../programs/zoxide.nix

--- a/nix/programs/lazydocker.nix
+++ b/nix/programs/lazydocker.nix
@@ -1,0 +1,6 @@
+{ pkgs, ... }:
+{
+  programs.lazydocker = {
+    enable = true;
+  };
+}

--- a/nix/programs/lazygit.nix
+++ b/nix/programs/lazygit.nix
@@ -1,0 +1,6 @@
+{ pkgs, ... }:
+{
+  programs.lazygit = {
+    enable = true;
+  };
+}


### PR DESCRIPTION
## Summary
- Add lazygit configuration for improved Git TUI workflows
- Add lazydocker configuration for Docker container management via TUI
- Update darwin home.nix to import both programs

## Test plan
- [ ] Build and switch to new configuration: `sudo darwin-rebuild switch --flake .#darwin --impure`
- [ ] Verify lazygit is available: `which lazygit`
- [ ] Verify lazydocker is available: `which lazydocker`
- [ ] Test lazygit functionality in a Git repository
- [ ] Test lazydocker functionality with Docker running

🤖 Generated with [Claude Code](https://claude.com/claude-code)