### PR TITLE
feat(nix): migrate bottom from Homebrew to home-manager

### DIFF
--- a/nix/hosts/darwin/configuration.nix
+++ b/nix/hosts/darwin/configuration.nix
@@ -139,7 +139,6 @@
       "bash"
       "bats-core"
       "borders"
-      "bottom"
       "broot"
       "cabextract"
       "cairo"

--- a/nix/hosts/darwin/home.nix
+++ b/nix/hosts/darwin/home.nix
@@ -14,6 +14,7 @@ in
     # ../../programs/bash.nix
     ../../programs/alacritty.nix
     ../../programs/bat.nix
+    ../../programs/bottom.nix
     ../../programs/git.nix
     ../../programs/helix.nix
     ../../programs/kakoune.nix

--- a/nix/programs/bottom.nix
+++ b/nix/programs/bottom.nix
@@ -1,0 +1,6 @@
+{ pkgs, ... }:
+{
+  programs.bottom = {
+    enable = true;
+  };
+}


### PR DESCRIPTION
## Summary
- Migrate `bottom` package management from Homebrew to Nix home-manager programs
- Create `nix/programs/bottom.nix` configuration file
- Remove `bottom` from Homebrew brews list in `configuration.nix`
- Add import to `home.nix`

## Benefits
- Better version control and reproducibility
- Consistent with other programs managed by home-manager (bat, lazygit, lazydocker, etc.)
- Improved integration with declarative configuration system

## Test plan
- [x] Run `sudo darwin-rebuild build --flake .#darwin --impure` to verify configuration builds successfully
- [x] Run `sudo darwin-rebuild switch --flake .#darwin --impure` to apply changes
- [x] Verify `bottom` is installed and working correctly
- [x] Verify `bottom` has been removed from Homebrew-managed packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)