### PR TITLE
feat(nixvim): add Neovide GUI settings

### DIFF
--- a/nix/programs/nixvim/options.nix
+++ b/nix/programs/nixvim/options.nix
@@ -76,6 +76,18 @@
     extraConfigLua = ''
       vim.scriptencoding = "utf-8"
       vim.opt.clipboard = vim.env.SSH_TTY and "" or "unnamedplus"
+
+      -- Neovide GUI settings
+      if vim.g.neovide then
+        vim.g.neovide_transparency = 0.5
+        vim.g.transparency = 0.8
+        vim.g.neovide_background_color = "#0f1117" .. string.format("%x", math.floor(255 * 0.8))
+        vim.g.neovide_window_blurred = true
+        vim.g.neovide_floating_shadow = true
+        vim.g.neovide_floating_shadow_amount_x = 2.0
+        vim.g.neovide_floating_shadow_amount_y = 2.0
+        vim.g.neovide_light_radius = 5
+      end
     '';
   };
 }


### PR DESCRIPTION
## Summary
- Add Neovide transparency, blur, and shadow settings to nixvim options

## Changes
- `options.nix`: Add `vim.g.neovide_*` settings in extraConfigLua

## Settings Added
- `neovide_transparency = 0.5`
- `transparency = 0.8`
- `neovide_background_color` with alpha
- `neovide_window_blurred = true`
- `neovide_floating_shadow = true`
- `neovide_light_radius = 5`

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)