### PR TITLE
feat(nixvim): enable AI integration plugins

### DIFF
--- a/nix/programs/nixvim/plugins/ai.nix
+++ b/nix/programs/nixvim/plugins/ai.nix
@@ -1,49 +1,46 @@
 # AI assistance plugins (Claude Code)
-{ ... }:
-# TODO: Re-enable when hash is updated
-# { pkgs, ... }:
-# let
-#   claudecode-nvim = pkgs.vimUtils.buildVimPlugin {
-#     pname = "claudecode-nvim";
-#     version = "2024-12-26";
-#     src = pkgs.fetchFromGitHub {
-#       owner = "coder";
-#       repo = "claudecode.nvim";
-#       rev = "6091df0e8edcdc92526cec23bbb42f63c0bb5ff2";
-#       hash = "sha256-PmSYIE7j9C2ckJc9wDIm4KCozXP0z1U9TOdItnDyoDQ=";
-#     };
-#   };
-# in
+{ pkgs, ... }:
+let
+  claude-code-nvim = pkgs.vimUtils.buildVimPlugin {
+    pname = "claude-code-nvim";
+    version = "2024-12-26";
+    src = pkgs.fetchFromGitHub {
+      owner = "greggh";
+      repo = "claude-code.nvim";
+      rev = "c9a31e51069977edaad9560473b5d031fcc5d38b";
+      hash = "sha256-ZEIPutxhgyaAhq+fJw1lTO781IdjTXbjKy5yKgqSLjM=";
+    };
+  };
+in
 {
   programs.nixvim = {
-    # TODO: Re-enable claudecode.nvim when hash is updated
-    # extraPlugins = [ claudecode-nvim ];
-    #
-    # extraConfigLua = ''
-    #   require("claudecode").setup({})
-    #
-    #   -- ft-specific keymap for adding files from file explorers
-    #   vim.api.nvim_create_autocmd("FileType", {
-    #     pattern = { "neo-tree", "oil", "minifiles", "netrw" },
-    #     callback = function(args)
-    #       vim.keymap.set("n", "<leader>as", "<cmd>ClaudeCodeTreeAdd<cr>", {
-    #         buffer = args.buf,
-    #         desc = "Add file",
-    #       })
-    #     end,
-    #   })
-    # '';
-    #
-    # keymaps = [
-    #   { mode = "n"; key = "<leader>ac"; action = "<cmd>ClaudeCode<cr>"; options.desc = "Toggle Claude"; }
-    #   { mode = "n"; key = "<leader>af"; action = "<cmd>ClaudeCodeFocus<cr>"; options.desc = "Focus Claude"; }
-    #   { mode = "n"; key = "<leader>ar"; action = "<cmd>ClaudeCode --resume<cr>"; options.desc = "Resume Claude"; }
-    #   { mode = "n"; key = "<leader>aC"; action = "<cmd>ClaudeCode --continue<cr>"; options.desc = "Continue Claude"; }
-    #   { mode = "n"; key = "<leader>am"; action = "<cmd>ClaudeCodeSelectModel<cr>"; options.desc = "Select Claude model"; }
-    #   { mode = "n"; key = "<leader>ab"; action = "<cmd>ClaudeCodeAdd %<cr>"; options.desc = "Add current buffer"; }
-    #   { mode = "v"; key = "<leader>as"; action = "<cmd>ClaudeCodeSend<cr>"; options.desc = "Send to Claude"; }
-    #   { mode = "n"; key = "<leader>aa"; action = "<cmd>ClaudeCodeDiffAccept<cr>"; options.desc = "Accept diff"; }
-    #   { mode = "n"; key = "<leader>ad"; action = "<cmd>ClaudeCodeDiffDeny<cr>"; options.desc = "Deny diff"; }
-    # ];
+    extraPlugins = [ claude-code-nvim ];
+
+    extraConfigLua = ''
+      require("claude-code").setup({})
+
+      -- ft-specific keymap for adding files from file explorers
+      vim.api.nvim_create_autocmd("FileType", {
+        pattern = { "neo-tree", "oil", "minifiles", "netrw" },
+        callback = function(args)
+          vim.keymap.set("n", "<leader>as", "<cmd>ClaudeCodeTreeAdd<cr>", {
+            buffer = args.buf,
+            desc = "Add file",
+          })
+        end,
+      })
+    '';
+
+    keymaps = [
+      { mode = "n"; key = "<leader>ac"; action = "<cmd>ClaudeCode<cr>"; options.desc = "Toggle Claude"; }
+      { mode = "n"; key = "<leader>af"; action = "<cmd>ClaudeCodeFocus<cr>"; options.desc = "Focus Claude"; }
+      { mode = "n"; key = "<leader>ar"; action = "<cmd>ClaudeCode --resume<cr>"; options.desc = "Resume Claude"; }
+      { mode = "n"; key = "<leader>aC"; action = "<cmd>ClaudeCode --continue<cr>"; options.desc = "Continue Claude"; }
+      { mode = "n"; key = "<leader>am"; action = "<cmd>ClaudeCodeSelectModel<cr>"; options.desc = "Select Claude model"; }
+      { mode = "n"; key = "<leader>ab"; action = "<cmd>ClaudeCodeAdd %<cr>"; options.desc = "Add current buffer"; }
+      { mode = "v"; key = "<leader>as"; action = "<cmd>ClaudeCodeSend<cr>"; options.desc = "Send to Claude"; }
+      { mode = "n"; key = "<leader>aa"; action = "<cmd>ClaudeCodeDiffAccept<cr>"; options.desc = "Accept diff"; }
+      { mode = "n"; key = "<leader>ad"; action = "<cmd>ClaudeCodeDiffDeny<cr>"; options.desc = "Deny diff"; }
+    ];
   };
 }

--- a/nix/programs/nixvim/plugins/completion.nix
+++ b/nix/programs/nixvim/plugins/completion.nix
@@ -1,18 +1,17 @@
 # Completion configuration (blink.cmp, copilot, snippets)
 { pkgs, ... }:
-# TODO: Re-enable when hash is updated
-# let
-#   blink-copilot = pkgs.vimUtils.buildVimPlugin {
-#     pname = "blink-copilot";
-#     version = "2024-12-26";
-#     src = pkgs.fetchFromGitHub {
-#       owner = "fang2hou";
-#       repo = "blink-copilot";
-#       rev = "7ad8209b2f880a2840c94cdcd80ab4dc511d4f39";
-#       hash = "sha256-cDvbUmnFZbPmU/HPISNV8zJV8WsH3COl3nGqgT5CbVQ=";
-#     };
-#   };
-# in
+let
+  blink-copilot = pkgs.vimUtils.buildVimPlugin {
+    pname = "blink-copilot";
+    version = "2024-12-26";
+    src = pkgs.fetchFromGitHub {
+      owner = "fang2hou";
+      repo = "blink-copilot";
+      rev = "7ad8209b2f880a2840c94cdcd80ab4dc511d4f39";
+      hash = "sha256-cDvbUmnFZbPmU/HPISNV8zJV8WsH3COl3nGqgT5CbVQ=";
+    };
+  };
+in
 {
   programs.nixvim = {
     plugins.blink-cmp = {
@@ -35,17 +34,15 @@
           nerd_font_variant = "mono";
         };
         sources = {
-          default = [ "lsp" "path" "snippets" "buffer" ];
-          # TODO: Re-enable copilot source when blink-copilot is enabled
-          # default = [ "lsp" "path" "snippets" "buffer" "copilot" ];
-          # providers = {
-          #   copilot = {
-          #     name = "copilot";
-          #     module = "blink-copilot";
-          #     score_offset = 100;
-          #     async = true;
-          #   };
-          # };
+          default = [ "lsp" "path" "snippets" "buffer" "copilot" ];
+          providers = {
+            copilot = {
+              name = "copilot";
+              module = "blink-copilot";
+              score_offset = 100;
+              async = true;
+            };
+          };
         };
         completion = {
           accept.auto_brackets.enabled = true;
@@ -69,7 +66,7 @@
 
     extraPlugins = with pkgs.vimPlugins; [
       friendly-snippets
-      # blink-copilot  # TODO: Re-enable when hash is updated
+      blink-copilot
     ];
   };
 }


### PR DESCRIPTION
## Summary
- Enable claude-code.nvim and blink-copilot plugins

## Changes

### ai.nix
- Enable `claude-code.nvim` from greggh/claude-code.nvim
- Add keymaps:
  - `<leader>ac` Toggle Claude
  - `<leader>af` Focus Claude
  - `<leader>ar` Resume Claude
  - `<leader>aC` Continue Claude
  - `<leader>am` Select model
  - `<leader>ab` Add current buffer
  - `<leader>as` Send to Claude (visual) / Add file (neo-tree)
  - `<leader>aa` Accept diff
  - `<leader>ad` Deny diff

### completion.nix
- Enable `blink-copilot` as completion source
- Add copilot provider to blink.cmp sources

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)