### PR TITLE
feat(nixvim): enable language-specific plugins

### DIFF
--- a/nix/programs/nixvim/plugins/lang/clojure.nix
+++ b/nix/programs/nixvim/plugins/lang/clojure.nix
@@ -1,18 +1,17 @@
 # Clojure development
 { pkgs, ... }:
-# TODO: Re-enable when hash is updated
-# let
-#   vim-jack-in = pkgs.vimUtils.buildVimPlugin {
-#     pname = "vim-jack-in";
-#     version = "2024-12-26";
-#     src = pkgs.fetchFromGitHub {
-#       owner = "clojure-vim";
-#       repo = "vim-jack-in";
-#       rev = "45e5293cff0802a51dbed31a9b0141b0f80e2952";
-#       hash = "sha256-4kYY0jUv5U2i+G/29vPOZHqUX/cEQTWBo9pghRg9gIw=";
-#     };
-#   };
-# in
+let
+  vim-jack-in = pkgs.vimUtils.buildVimPlugin {
+    pname = "vim-jack-in";
+    version = "2024-12-26";
+    src = pkgs.fetchFromGitHub {
+      owner = "clojure-vim";
+      repo = "vim-jack-in";
+      rev = "45e5293cff0802a51dbed31a9b0141b0f80e2952";
+      hash = "sha256-4kYY0jUv5U2i+G/29vPOZHqUX/cEQTWBo9pghRg9gIw=";
+    };
+  };
+in
 {
   programs.nixvim = {
     globals."conjure#mapping#doc_word" = "K";
@@ -21,7 +20,7 @@
 
     extraPlugins = with pkgs.vimPlugins; [
       nvim-paredit
-      # vim-jack-in  # TODO: Re-enable when hash is updated
+      vim-jack-in
     ];
 
     extraConfigLua = ''

--- a/nix/programs/nixvim/plugins/lang/dotnet.nix
+++ b/nix/programs/nixvim/plugins/lang/dotnet.nix
@@ -1,22 +1,19 @@
 # .NET/C# development
-{ ... }:
-# TODO: Re-enable when hash is updated
-# { pkgs, ... }:
-# let
-#   omnisharp-extended-lsp = pkgs.vimUtils.buildVimPlugin {
-#     pname = "omnisharp-extended-lsp-nvim";
-#     version = "2024-12-26";
-#     src = pkgs.fetchFromGitHub {
-#       owner = "Hoffs";
-#       repo = "omnisharp-extended-lsp.nvim";
-#       rev = "5b667daab948090931de0b31e4d58c6a6b0dce2f";
-#       hash = "sha256-YBJkW4ycKSWdB3lqZJKOCaieUt7xWyYw5kqN8RZxn90=";
-#     };
-#   };
-# in
+{ pkgs, ... }:
+let
+  omnisharp-extended-lsp = pkgs.vimUtils.buildVimPlugin {
+    pname = "omnisharp-extended-lsp-nvim";
+    version = "2024-12-26";
+    src = pkgs.fetchFromGitHub {
+      owner = "Hoffs";
+      repo = "omnisharp-extended-lsp.nvim";
+      rev = "a47388e5417e7f1cfa6962cc441a23c4c5fb2151";
+      hash = "sha256-0cRngH9BFuBbEu7007Xqr5zVJSBUowni7jxaMxGwnzU=";
+    };
+  };
+in
 {
   programs.nixvim = {
-    # TODO: Re-enable omnisharp-extended-lsp when hash is updated
-    # extraPlugins = [ omnisharp-extended-lsp ];
+    extraPlugins = [ omnisharp-extended-lsp ];
   };
 }

--- a/nix/programs/nixvim/plugins/lang/lisp.nix
+++ b/nix/programs/nixvim/plugins/lang/lisp.nix
@@ -1,24 +1,21 @@
 # Common Lisp development
-{ ... }:
-# TODO: Re-enable when hash is updated
-# { pkgs, ... }:
-# let
-#   vlime = pkgs.vimUtils.buildVimPlugin {
-#     pname = "vlime";
-#     version = "2024-12-26";
-#     src = pkgs.fetchFromGitHub {
-#       owner = "vlime";
-#       repo = "vlime";
-#       rev = "e276e9a6f37d2699a3caa63be19314f5a19a1481";
-#       hash = "sha256-tCqN80lgj11ggzGmuGF077oqL5ByjUp6jVmRUTrIWJA=";
-#     };
-#   };
-# in
+{ pkgs, ... }:
+let
+  vlime = pkgs.vimUtils.buildVimPlugin {
+    pname = "vlime";
+    version = "2024-12-26";
+    src = pkgs.fetchFromGitHub {
+      owner = "vlime";
+      repo = "vlime";
+      rev = "e276e9a6f37d2699a3caa63be19314f5a19a1481";
+      hash = "sha256-tCqN80lgj11ggzGmuGF077oqL5ByjUp6jVmRUTrIWJA=";
+    };
+  };
+in
 {
   programs.nixvim = {
     globals.vlime_cl_impl = "sbcl";
 
-    # TODO: Re-enable vlime when hash is updated
-    # extraPlugins = [ vlime ];
+    extraPlugins = [ vlime ];
   };
 }

--- a/nix/programs/nixvim/plugins/lang/python.nix
+++ b/nix/programs/nixvim/plugins/lang/python.nix
@@ -1,30 +1,27 @@
 # Python development
-{ ... }:
-# TODO: Re-enable when hash is updated
-# { pkgs, ... }:
-# let
-#   venv-selector-nvim = pkgs.vimUtils.buildVimPlugin {
-#     pname = "venv-selector-nvim";
-#     version = "2024-12-26";
-#     src = pkgs.fetchFromGitHub {
-#       owner = "linux-cultist";
-#       repo = "venv-selector.nvim";
-#       rev = "f16c804fbb375d14b69063053f4b2ba66398b4bd";
-#       hash = "sha256-5xmKjaN6CMvSwbQ+PpxqsQ1Ps+6IJoDuemXs78J25SY=";
-#     };
-#   };
-# in
+{ pkgs, ... }:
+let
+  venv-selector-nvim = pkgs.vimUtils.buildVimPlugin {
+    pname = "venv-selector-nvim";
+    version = "2024-12-26";
+    src = pkgs.fetchFromGitHub {
+      owner = "linux-cultist";
+      repo = "venv-selector.nvim";
+      rev = "d2326e7433fdeb10f7d0d1237c18b91b353f9f8b";
+      hash = "sha256-9fVH/EBbssmsUnZNxhxJC6d3sDImIqKtq5nFl/T8L7o=";
+    };
+  };
+in
 {
   programs.nixvim = {
-    # TODO: Re-enable venv-selector when hash is updated
-    # extraPlugins = [ venv-selector-nvim ];
-    #
-    # extraConfigLua = ''
-    #   require("venv-selector").setup({})
-    # '';
-    #
-    # keymaps = [
-    #   { mode = "n"; key = "<leader>cv"; action = "<cmd>VenvSelect<cr>"; options.desc = "Select VirtualEnv"; }
-    # ];
+    extraPlugins = [ venv-selector-nvim ];
+
+    extraConfigLua = ''
+      require("venv-selector").setup({})
+    '';
+
+    keymaps = [
+      { mode = "n"; key = "<leader>cv"; action = "<cmd>VenvSelect<cr>"; options.desc = "Select VirtualEnv"; }
+    ];
   };
 }

--- a/nix/programs/nixvim/plugins/lang/web.nix
+++ b/nix/programs/nixvim/plugins/lang/web.nix
@@ -1,35 +1,32 @@
 # Web development (templates, tailwind)
-{ ... }:
-# TODO: Re-enable when hash is updated
-# { pkgs, ... }:
-# let
-#   vim-slim = pkgs.vimUtils.buildVimPlugin {
-#     pname = "vim-slim";
-#     version = "2024-12-26";
-#     src = pkgs.fetchFromGitHub {
-#       owner = "slim-template";
-#       repo = "vim-slim";
-#       rev = "a0a57f75f20a03d5fa798484743e98f4af623926";
-#       hash = "sha256-mPv0tiggGExEZNshDlHtT4ipv/5Q0ahkcVw4irJ8l3o=";
-#     };
-#   };
-#   tailwindcss-colorizer-cmp = pkgs.vimUtils.buildVimPlugin {
-#     pname = "tailwindcss-colorizer-cmp-nvim";
-#     version = "2024-12-26";
-#     src = pkgs.fetchFromGitHub {
-#       owner = "roobert";
-#       repo = "tailwindcss-colorizer-cmp.nvim";
-#       rev = "3d3cd95e4a4135c250faf83dd5ed61b8e5502b86";
-#       hash = "sha256-PIkfJzLt001TojAnE/rdRhgVEwSvCvUJm/vNPLSWjpY=";
-#     };
-#   };
-# in
+{ pkgs, ... }:
+let
+  vim-slim = pkgs.vimUtils.buildVimPlugin {
+    pname = "vim-slim";
+    version = "2024-12-26";
+    src = pkgs.fetchFromGitHub {
+      owner = "slim-template";
+      repo = "vim-slim";
+      rev = "a0a57f75f20a03d5fa798484743e98f4af623926";
+      hash = "sha256-mPv0tiggGExEZNshDlHtT4ipv/5Q0ahkcVw4irJ8l3o=";
+    };
+  };
+  tailwindcss-colorizer-cmp = pkgs.vimUtils.buildVimPlugin {
+    pname = "tailwindcss-colorizer-cmp-nvim";
+    version = "2024-12-26";
+    src = pkgs.fetchFromGitHub {
+      owner = "roobert";
+      repo = "tailwindcss-colorizer-cmp.nvim";
+      rev = "3d3cd95e4a4135c250faf83dd5ed61b8e5502b86";
+      hash = "sha256-PIkfJzLt001TojAnE/rdRhgVEwSvCvUJm/vNPLSWjpY=";
+    };
+  };
+in
 {
   programs.nixvim = {
-    # TODO: Re-enable vim-slim and tailwindcss-colorizer-cmp when hash is updated
-    # extraPlugins = [
-    #   vim-slim
-    #   tailwindcss-colorizer-cmp
-    # ];
+    extraPlugins = [
+      vim-slim
+      tailwindcss-colorizer-cmp
+    ];
   };
 }


### PR DESCRIPTION
## Summary
- Enable venv-selector.nvim for Python virtual environment selection
- Enable vim-jack-in for Clojure REPL integration with conjure
- Enable vlime for Common Lisp development
- Enable vim-slim for Slim template syntax highlighting
- Enable tailwindcss-colorizer-cmp for Tailwind CSS color preview
- Enable omnisharp-extended-lsp for .NET decompilation support

Closes #36

## Test plan
- [x] darwin-rebuild build succeeds
- [x] darwin-rebuild switch completes
- [x] vlime globals correctly set (sbcl)
- [x] venv-selector loads successfully
- [x] nvim-paredit loads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)