### PR TITLE
fix(nixvim): enable gopls LSP with explicit Nix path

### DIFF
--- a/nix/programs/nixvim/plugins/lsp.nix
+++ b/nix/programs/nixvim/plugins/lsp.nix
@@ -18,7 +18,6 @@
           };
         };
         ts_ls.enable = true;
-        # gopls.enable = true;  # TODO: Re-enable after nixpkgs version check issue is fixed
         pyright.enable = true;
         # rust_analyzer is handled by rustaceanvim
         ruby_lsp.enable = true;
@@ -76,6 +75,12 @@
     };
 
     extraConfigLua = ''
+      -- gopls setup (manual config to bypass nixpkgs version check issue)
+      require("lspconfig").gopls.setup({
+        cmd = { "${pkgs.gopls}/bin/gopls" },
+        capabilities = require("blink.cmp").get_lsp_capabilities(),
+      })
+
       -- Diagnostics config
       vim.diagnostic.config({
         underline = true,
@@ -97,8 +102,9 @@
     '';
   };
 
-  # Install formatters via Nix (replaces Mason)
+  # Install formatters and LSP servers via Nix (replaces Mason)
   home.packages = with pkgs; [
+    gopls  # Go LSP (installed separately to bypass nixpkgs build check)
     stylua
     shfmt
     prettierd


### PR DESCRIPTION
## Summary
- Configure gopls manually via lspconfig to bypass nixpkgs version check issue
- Install gopls via `home.packages` instead of Nixvim's built-in server
- Use explicit Nix store path (`${pkgs.gopls}/bin/gopls`) in lspconfig cmd
- Add blink.cmp capabilities for completion integration

## Root cause
Nixvim's `servers.gopls.enable = true` triggers a nixpkgs build-time version check that fails with permission errors:
```
Did not find version 0.21.0 in the output of the command gopls version
gopls cannot access its persistent index (disk full?): mkdir /tmp/gopls/...: permission denied
```

## Solution
Manually configure gopls via `extraConfigLua` + `require("lspconfig").gopls.setup()`, using the explicit Nix store path to ensure the correct binary is used regardless of PATH.

Closes #37

## Test plan
- [x] darwin-rebuild build succeeds
- [x] darwin-rebuild switch completes
- [x] gopls attaches to .go files
- [x] gopls uses Nix-installed version (0.21.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)