### PR TITLE
refactor(nix): adopt mkOutOfStoreSymlink helper

### DIFF
--- a/nix/hosts/siraken-macmini/home.nix
+++ b/nix/hosts/siraken-macmini/home.nix
@@ -1,14 +1,20 @@
 {
   config,
   pkgs,
-  lib,
   inputs,
   ...
 }:
 let
   dotfilesPath = "${config.home.homeDirectory}/dotfiles";
+  # Out-of-store symlink helper: links the repo checkout directly into place so
+  # the target is editable without a rebuild. The argument must be a string path
+  # (a path literal would be copied into the store). See #70.
+  mkRepoLink = rel: config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/${rel}";
 in
 {
+  # Expose the helper to imported program modules (see #71).
+  _module.args.mkRepoLink = mkRepoLink;
+
   imports = [
     inputs.op-shell-plugins.hmModules.default
     # programs (cross-platform)
@@ -60,14 +66,11 @@ in
     sessionPath = import ../../modules/path.nix { };
     shellAliases = import ../../modules/aliases.nix { inherit pkgs; };
 
+    # Mutable (out-of-store) symlinks: edited in place, no rebuild required.
     file = {
-
+      ".config/wezterm".source = mkRepoLink "nix/programs/wezterm/config";
+      ".claude/settings.json".source = mkRepoLink ".agents/claude/settings.json";
     };
-
-    activation.mutableSymlinks = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      ln -sfn ${dotfilesPath}/nix/programs/wezterm/config $HOME/.config/wezterm
-      ln -sfn ${dotfilesPath}/.agents/claude/settings.json $HOME/.claude/settings.json
-    '';
 
     shell = {
       enableBashIntegration = true;

--- a/nix/hosts/siraken-mbp/home.nix
+++ b/nix/hosts/siraken-mbp/home.nix
@@ -1,14 +1,20 @@
 {
   config,
   pkgs,
-  lib,
   inputs,
   ...
 }:
 let
   dotfilesPath = "${config.home.homeDirectory}/dotfiles";
+  # Out-of-store symlink helper: links the repo checkout directly into place so
+  # the target is editable without a rebuild. The argument must be a string path
+  # (a path literal would be copied into the store). See #70.
+  mkRepoLink = rel: config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/${rel}";
 in
 {
+  # Expose the helper to imported program modules (see #71).
+  _module.args.mkRepoLink = mkRepoLink;
+
   imports = [
     inputs.op-shell-plugins.hmModules.default
     # inputs.dotfiles-private.homeManagerModules.default
@@ -62,14 +68,11 @@ in
     sessionPath = import ../../modules/path.nix { };
     shellAliases = import ../../modules/aliases.nix { inherit pkgs; };
 
+    # Mutable (out-of-store) symlinks: edited in place, no rebuild required.
     file = {
-
+      ".config/wezterm".source = mkRepoLink "nix/programs/wezterm/config";
+      ".claude/settings.json".source = mkRepoLink ".agents/claude/settings.json";
     };
-
-    activation.mutableSymlinks = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      ln -sfn ${dotfilesPath}/nix/programs/wezterm/config $HOME/.config/wezterm
-      ln -sfn ${dotfilesPath}/.agents/claude/settings.json $HOME/.claude/settings.json
-    '';
 
     shell = {
       enableBashIntegration = true;


### PR DESCRIPTION
## Summary

Foundation for #70 (out-of-store symlink migration).

- Add a shared `mkRepoLink` helper and expose it via `_module.args` so follow-up
  tool modules can reuse the same pattern.
- Replace the hand-written `ln -sfn` activation for `wezterm` and
  `claude/settings.json` with `home.file` + `config.lib.file.mkOutOfStoreSymlink`,
  so these links join home-manager's generation management (cleanup +
  `hm-backup` on conflict).
- Remove the now-unused `lib` module argument.
- Applied to both `siraken-mbp` and `siraken-macmini`.

## Verification

- `darwin-rebuild build --flake .#siraken-mbp --impure` succeeds (build only, no switch).
- The generated `home-manager-files` entries resolve to the repo checkout:
  - `.config/wezterm` → `…/dotfiles/nix/programs/wezterm/config`
  - `.claude/settings.json` → `…/dotfiles/.agents/claude/settings.json`
- `nix fmt` reports 0 changed.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)
