### PR TITLE
refactor(nix): share mkRepoLink via a home module

### DIFF
--- a/nix/home/wsl-ubuntu/home.nix
+++ b/nix/home/wsl-ubuntu/home.nix
@@ -17,6 +17,7 @@
   };
 
   imports = [
+    ../../modules/home/mk-repo-link.nix
     inputs.op-shell-plugins.hmModules.default
     inputs.nixvim.homeModules.nixvim
     # inputs.dotfiles-private.homeManagerModules.default

--- a/nix/hosts/nixos-vm/home.nix
+++ b/nix/hosts/nixos-vm/home.nix
@@ -10,6 +10,7 @@ let
 in
 {
   imports = [
+    ../../modules/home/mk-repo-link.nix
     # programs (cross-platform)
     ../../programs/atuin
     ../../programs/awscli

--- a/nix/hosts/siraken-macmini/home.nix
+++ b/nix/hosts/siraken-macmini/home.nix
@@ -1,21 +1,12 @@
 {
-  config,
   pkgs,
   inputs,
+  mkRepoLink,
   ...
 }:
-let
-  dotfilesPath = "${config.home.homeDirectory}/dotfiles";
-  # Out-of-store symlink helper: links the repo checkout directly into place so
-  # the target is editable without a rebuild. The argument must be a string path
-  # (a path literal would be copied into the store). See #70.
-  mkRepoLink = rel: config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/${rel}";
-in
 {
-  # Expose the helper to imported program modules (see #71).
-  _module.args.mkRepoLink = mkRepoLink;
-
   imports = [
+    ../../modules/home/mk-repo-link.nix
     inputs.op-shell-plugins.hmModules.default
     # programs (cross-platform)
     ../../programs/atuin

--- a/nix/hosts/siraken-mbp/home.nix
+++ b/nix/hosts/siraken-mbp/home.nix
@@ -1,21 +1,12 @@
 {
-  config,
   pkgs,
   inputs,
+  mkRepoLink,
   ...
 }:
-let
-  dotfilesPath = "${config.home.homeDirectory}/dotfiles";
-  # Out-of-store symlink helper: links the repo checkout directly into place so
-  # the target is editable without a rebuild. The argument must be a string path
-  # (a path literal would be copied into the store). See #70.
-  mkRepoLink = rel: config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/${rel}";
-in
 {
-  # Expose the helper to imported program modules (see #71).
-  _module.args.mkRepoLink = mkRepoLink;
-
   imports = [
+    ../../modules/home/mk-repo-link.nix
     inputs.op-shell-plugins.hmModules.default
     # inputs.dotfiles-private.homeManagerModules.default
     # programs (cross-platform)

--- a/nix/hosts/wsl-nixos/home.nix
+++ b/nix/hosts/wsl-nixos/home.nix
@@ -7,6 +7,7 @@
 }:
 {
   imports = [
+    ../../modules/home/mk-repo-link.nix
     inputs.op-shell-plugins.hmModules.default
     # programs (cross-platform)
     ../../programs/1password-shell-plugins

--- a/nix/modules/home/mk-repo-link.nix
+++ b/nix/modules/home/mk-repo-link.nix
@@ -1,0 +1,14 @@
+# Provides the `mkRepoLink` helper to all home-manager program modules via
+# `_module.args`. It returns an out-of-store symlink into the ~/dotfiles
+# checkout, so the linked file is editable in place without a rebuild.
+#
+# The argument is a path string relative to the repo root, e.g.
+# `mkRepoLink "nix/programs/nano/nanorc"`. It must be a string (a path literal
+# would be copied into the Nix store and defeat the out-of-store intent).
+#
+# Assumes the repo is checked out at `~/dotfiles`. See #70.
+{ config, ... }:
+{
+  _module.args.mkRepoLink =
+    rel: config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/${rel}";
+}


### PR DESCRIPTION
## Summary

Foundation follow-up for #70. Generalizes the `mkRepoLink` helper (added for
mbp/macmini in #71) so **all build-target profiles** can use it — required
before migrating shared program modules (nano, tmux, git, ...) that are
imported by multiple profiles.

- New reusable module `nix/modules/home/mk-repo-link.nix` exposing
  `_module.args.mkRepoLink` (out-of-store symlink into the `~/dotfiles` checkout).
- Replace the per-host `let`-bindings in `siraken-mbp` / `siraken-macmini` with
  an import of the shared module.
- Import the module in `wsl-ubuntu`, `wsl-nixos`, `nixos-vm` as well.
- `minimal` / `pixel10` are intentionally excluded (not flake outputs;
  `minimal` already references a non-existent `symlinks.nix`).

## Verification

- `darwin-rebuild build` succeeds for both `siraken-mbp` and `siraken-macmini`
  (build only, no switch).
- wezterm/claude still resolve out-of-store to the repo checkout:
  - `.config/wezterm` → `…/dotfiles/nix/programs/wezterm/config`
  - `.claude/settings.json` → `…/dotfiles/.agents/claude/settings.json`
- `wsl-ubuntu` / `wsl-nixos` / `nixos-vm` evaluate cleanly (import health);
  full x86_64-linux build is covered by CI.

Part of #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
