### PR TITLE
refactor(nano): use out-of-store symlink for nanorc

### DIFF
--- a/nix/programs/nano/default.nix
+++ b/nix/programs/nano/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ mkRepoLink, ... }:
 {
-  home.file.".config/nano/nanorc".source = ./nanorc;
+  home.file.".config/nano/nanorc".source = mkRepoLink "nix/programs/nano/nanorc";
 }


### PR DESCRIPTION
## Summary

Migrates `nano` to an out-of-store symlink (part of #70).

- Replace `home.file.source = ./nanorc` with `mkRepoLink "nix/programs/nano/nanorc"`.
- `nanorc` contents are unchanged — only the link mechanism changes (store copy →
  out-of-store symlink into the repo checkout), so behavior is identical.

## Verification

- `darwin-rebuild build .#siraken-mbp` succeeds; `~/.config/nano/nanorc` resolves
  to `…/dotfiles/nix/programs/nano/nanorc`.
- `wsl-ubuntu` / `wsl-nixos` (which also import nano) evaluate cleanly —
  `mkRepoLink` resolves; full Linux build covered by CI.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)
