### PR TITLE
refactor(idea): use out-of-store symlink for .ideavimrc

### DIFF
--- a/nix/programs/idea/default.nix
+++ b/nix/programs/idea/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ mkRepoLink, ... }:
 {
-  home.file.".ideavimrc".source = ./.ideavimrc;
+  home.file.".ideavimrc".source = mkRepoLink "nix/programs/idea/.ideavimrc";
 }


### PR DESCRIPTION
## Summary

Migrates `idea` (.ideavimrc) to an out-of-store symlink (part of #70).

- Replace `home.file.source = ./.ideavimrc` with `mkRepoLink "nix/programs/idea/.ideavimrc"`.
- Contents unchanged — only the link mechanism changes (store copy → out-of-store
  symlink into the repo checkout), so behavior is identical.

## Verification

- `darwin-rebuild build .#siraken-mbp` succeeds; `~/.ideavimrc` resolves to
  `…/dotfiles/nix/programs/idea/.ideavimrc`.
- `wsl-ubuntu` / `wsl-nixos` (which also import idea) evaluate cleanly; full Linux
  build covered by CI.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)
