### PR TITLE
refactor(husky): use out-of-store symlink for init.sh

### DIFF
--- a/nix/programs/husky/default.nix
+++ b/nix/programs/husky/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ mkRepoLink, ... }:
 {
-  home.file.".config/husky/init.sh".source = ./init.sh;
+  home.file.".config/husky/init.sh".source = mkRepoLink "nix/programs/husky/init.sh";
 }


### PR DESCRIPTION
## Summary

Migrates `husky` (init.sh) to an out-of-store symlink (part of #70).

- Replace `home.file.source = ./init.sh` with `mkRepoLink "nix/programs/husky/init.sh"`.
- Contents unchanged — only the link mechanism changes (store copy → out-of-store
  symlink into the repo checkout), so behavior is identical.

## Verification

- `darwin-rebuild build .#siraken-mbp` succeeds; `~/.config/husky/init.sh` resolves
  to `…/dotfiles/nix/programs/husky/init.sh`.
- `wsl-ubuntu` / `wsl-nixos` (which also import husky) evaluate cleanly; full Linux
  build covered by CI.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)
