### PR TITLE
refactor(ghostty): read static config from repo via config-file

### DIFF
--- a/nix/programs/ghostty/config
+++ b/nix/programs/ghostty/config
@@ -1,0 +1,27 @@
+shell-integration = detect
+
+# Font settings
+font-family = Hack Nerd Font Mono
+adjust-cell-height = 20%
+
+# Appearance
+theme = TokyoNight
+background-opacity = 0.7
+background-blur-radius = 13
+
+# Window settings
+window-vsync = true
+window-padding-x = 0
+window-padding-y = 0
+window-padding-color = background
+# window-decoration = none
+window-inherit-working-directory = true
+macos-titlebar-style = tabs
+
+unfocused-split-opacity = 0.3
+focus-follows-mouse = false
+confirm-close-surface = false
+quit-after-last-window-closed = true
+
+keybind = alt+d=new_split:right
+keybind = alt+shift+d=new_split:down

--- a/nix/programs/ghostty/default.nix
+++ b/nix/programs/ghostty/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 let
   isDarwin = pkgs.stdenv.isDarwin;
 in
@@ -12,36 +12,12 @@ in
       else
         pkgs.ghostty;
     settings = {
-      shell-integration = "detect";
-
-      # Font settings
-      font-family = "Hack Nerd Font Mono";
+      # Static settings live in a repo file read directly by ghostty via the
+      # `config-file` directive, so they are editable in place (ghostty reloads
+      # without a rebuild). Only the host-varying `font-size` stays in Nix,
+      # alongside the darwin/linux `package` choice. See #70.
+      config-file = "${config.home.homeDirectory}/dotfiles/nix/programs/ghostty/config";
       font-size = if isDarwin then 16 else 12;
-      adjust-cell-height = "20%";
-
-      # Appearance
-      theme = "TokyoNight";
-      background-opacity = 0.7;
-      background-blur-radius = 13;
-
-      # Window settings
-      window-vsync = true;
-      window-padding-x = 0;
-      window-padding-y = 0;
-      window-padding-color = "background";
-      # window-decoration = "none";
-      window-inherit-working-directory = true;
-      macos-titlebar-style = "tabs";
-
-      unfocused-split-opacity = 0.3;
-      focus-follows-mouse = false;
-      confirm-close-surface = false;
-      quit-after-last-window-closed = true;
-
-      keybind = [
-        "alt+d=new_split:right"
-        "alt+shift+d=new_split:down"
-      ];
     };
   };
 }


### PR DESCRIPTION
## Summary

Migrates `ghostty` so its static settings live in a repo file editable in place,
without changing behavior (part of #70).

- Add `nix/programs/ghostty/config` with all static settings (same values as before).
- `programs.ghostty.settings` now only sets `config-file` (absolute path to the
  repo file) and the host-varying `font-size`; the darwin/linux `package` choice
  is kept.
- ghostty loads the repo file via its `config-file` directive → editable in place,
  reloads without a rebuild. Avoids the home-manager/native-file collision on
  `~/.config/ghostty/config`.

## Why config-file instead of a plain out-of-store symlink

`font-size` differs per host (darwin 16 / linux 12) and `package` differs too, so a
single static file can't carry them. Keeping them in `settings` makes home-manager
generate `~/.config/ghostty/config`, which would collide with a symlink at the same
path. `config-file` keeps the generated config tiny (pointer + font-size) while the
bulk lives in the editable repo file.

## Verification

- `darwin-rebuild build .#siraken-mbp` succeeds.
- Generated config (mbp): `config-file = …/dotfiles/nix/programs/ghostty/config` + `font-size = 16`.
- font-size branch preserved: **mbp=16, macmini=16, nixos-vm=12**.
- All original setting keys present (static file + font-size) → behavior identical.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)
