### PR TITLE
refactor(kitty): include static config from repo

### DIFF
--- a/nix/programs/kitty/default.nix
+++ b/nix/programs/kitty/default.nix
@@ -1,15 +1,13 @@
-{ pkgs, ... }:
+{ config, ... }:
 {
   programs.kitty = {
     enable = true;
 
-    settings = {
-      font_size = "16.0";
-      tab_bar_edge = "top";
-      tab_bar_style = "powerline";
-      background_opacity = "0.5";
-      background_blur = 1;
-      dynamic_background_opacity = true;
-    };
+    # Static settings live in a repo file included directly by kitty, so they
+    # are editable in place (kitty reloads without a rebuild). home-manager
+    # still owns the generated kitty.conf (e.g. shell integration). See #70.
+    extraConfig = ''
+      include ${config.home.homeDirectory}/dotfiles/nix/programs/kitty/kitty.conf
+    '';
   };
 }

--- a/nix/programs/kitty/kitty.conf
+++ b/nix/programs/kitty/kitty.conf
@@ -1,0 +1,6 @@
+font_size 16.0
+tab_bar_edge top
+tab_bar_style powerline
+background_opacity 0.5
+background_blur 1
+dynamic_background_opacity yes


### PR DESCRIPTION
## Summary

Migrates `kitty` static settings to an editable repo file (part of #70).

- Add `nix/programs/kitty/kitty.conf` with the previous `settings` values.
- `programs.kitty.extraConfig` now `include`s the repo file; `settings` removed.
- home-manager still generates `~/.config/kitty/kitty.conf` (keeping its
  auto-injected `shell_integration no-rc`) and includes the repo file.

## Why include instead of a plain symlink

home-manager auto-injects `shell_integration no-rc` into the generated kitty.conf.
Replacing the whole file with an out-of-store symlink would drop that. `include`
keeps home-manager's shell integration while making the static settings editable.

## Verification

- `darwin-rebuild build .#siraken-mbp` succeeds.
- Generated kitty.conf keeps `shell_integration no-rc` and adds
  `include …/dotfiles/nix/programs/kitty/kitty.conf`.
- All original settings present (static file + shell integration) → behavior identical.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
