### PR TITLE
refactor(tmux): source custom config from repo

### DIFF
--- a/nix/programs/tmux/default.nix
+++ b/nix/programs/tmux/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 {
   programs.tmux = {
     enable = true;
@@ -35,38 +35,12 @@
       }
     ];
 
-    # Custom configuration
+    # Custom config lives in a repo file sourced directly, so it is editable in
+    # place (reload with `tmux source-file` — no rebuild). The structured
+    # options above, the shell, and plugins stay in Nix because they resolve
+    # store paths. See #70.
     extraConfig = ''
-      # Display settings
-      set -g display-time 2000
-      set -g repeat-time 0
-
-      # Pane navigation
-      bind -r h select-pane -L
-      bind -r j select-pane -D
-      bind -r k select-pane -U
-      bind -r l select-pane -R
-
-      # Pane resizing
-      bind -r C-k resize-pane -U 5
-      bind -r C-j resize-pane -D 5
-      bind -r C-h resize-pane -L 5
-      bind -r C-l resize-pane -R 5
-
-      # Kill all other panes
-      bind -r e kill-pane -a
-
-      # Window swapping
-      bind -n C-S-Left swap-window -t -1 \; previous-window
-      bind -n C-S-Right swap-window -t +1 \; next-window
-
-      # Window titles
-      set -g set-titles on
-      set -g set-titles-string "#T"
-
-      # Status bar
-      set -g status-interval 1
-      set -g status-justify 'left'
+      source-file ${config.home.homeDirectory}/dotfiles/nix/programs/tmux/tmux.conf
     '';
   };
 }

--- a/nix/programs/tmux/tmux.conf
+++ b/nix/programs/tmux/tmux.conf
@@ -1,0 +1,30 @@
+# Display settings
+set -g display-time 2000
+set -g repeat-time 0
+
+# Pane navigation
+bind -r h select-pane -L
+bind -r j select-pane -D
+bind -r k select-pane -U
+bind -r l select-pane -R
+
+# Pane resizing
+bind -r C-k resize-pane -U 5
+bind -r C-j resize-pane -D 5
+bind -r C-h resize-pane -L 5
+bind -r C-l resize-pane -R 5
+
+# Kill all other panes
+bind -r e kill-pane -a
+
+# Window swapping
+bind -n C-S-Left swap-window -t -1 \; previous-window
+bind -n C-S-Right swap-window -t +1 \; next-window
+
+# Window titles
+set -g set-titles on
+set -g set-titles-string "#T"
+
+# Status bar
+set -g status-interval 1
+set -g status-justify 'left'


### PR DESCRIPTION
## Summary

Migrates tmux's custom config block to an editable repo file (part of #70).

- Add `nix/programs/tmux/tmux.conf` with the previous `extraConfig` (keybinds /
  status / titles).
- `programs.tmux.extraConfig` now `source-file`s the repo file.
- Structured options (`baseIndex`, `keyMode`, ...), `shell`, and `plugins` stay
  in Nix — they resolve store paths (`default-shell`, plugin `run-shell`) that
  can't be hardcoded in a static file.

## Why partial (source-file) not full native

The generated tmux.conf embeds store paths for `default-shell` and the
tokyo-night-tmux plugin's `run-shell`. Hardcoding them in a static file would
break reproducibility. So only the store-path-free custom block moves out; it is
read via `source-file` at the exact same position, keeping order identical.

## Verification

- `darwin-rebuild build .#siraken-mbp` succeeds.
- Generated tmux.conf head (structured options + `default-shell`) unchanged.
- Generated tmux.conf tail: plugin `run-shell` unchanged + `source-file
  …/dotfiles/nix/programs/tmux/tmux.conf` in place of the inline custom block.
- repo tmux.conf == the previous extraConfig content → behavior identical.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)
