### PR TITLE
refactor(bash): source shell fragments from out-of-store symlinks

### DIFF
--- a/nix/programs/bash/default.nix
+++ b/nix/programs/bash/default.nix
@@ -1,10 +1,9 @@
-{ pkgs, lib, ... }:
-let
-  functionsScript = builtins.readFile ./function.sh;
-  messagesScript = builtins.readFile ./messages.sh;
-  aliasesScript = builtins.readFile ./alias.sh;
-  evalScript = builtins.readFile ./eval.sh;
-in
+{
+  pkgs,
+  config,
+  mkRepoLink,
+  ...
+}:
 {
   programs.bash = {
     enable = true;
@@ -27,19 +26,28 @@ in
       "checkwinsize"
     ];
 
-    # Extra configuration for .bashrc
+    # Source the fragments from out-of-store symlinks so they are editable in
+    # place (a new shell picks up edits — no rebuild). Same order as before.
+    # See #70.
     initExtra = ''
       # Message functions
-      ${messagesScript}
+      source ${config.home.homeDirectory}/.config/bash/messages.sh
 
       # Conditional aliases
-      ${aliasesScript}
+      source ${config.home.homeDirectory}/.config/bash/alias.sh
 
       # Custom functions
-      ${functionsScript}
+      source ${config.home.homeDirectory}/.config/bash/function.sh
 
       # External tools (GCP, Angular CLI)
-      ${evalScript}
+      source ${config.home.homeDirectory}/.config/bash/eval.sh
     '';
+  };
+
+  home.file = {
+    ".config/bash/messages.sh".source = mkRepoLink "nix/programs/bash/messages.sh";
+    ".config/bash/alias.sh".source = mkRepoLink "nix/programs/bash/alias.sh";
+    ".config/bash/function.sh".source = mkRepoLink "nix/programs/bash/function.sh";
+    ".config/bash/eval.sh".source = mkRepoLink "nix/programs/bash/eval.sh";
   };
 }


### PR DESCRIPTION
## Summary

Migrates bash's shell fragments to editable out-of-store symlinks (part of #70).

- `function.sh` / `alias.sh` / `eval.sh` / `messages.sh` are now symlinked under
  `~/.config/bash` via `mkRepoLink`.
- `programs.bash.initExtra` sources them (same order: messages → alias → function
  → eval) instead of inlining their contents via `readFile`.
- The fragments have no `$BASH_SOURCE`/self-path dependencies, so `source` is
  behaviorally identical to the previous inlining.

## Verification

- `darwin-rebuild build .#siraken-mbp` succeeds.
- Generated `.bashrc` sources the four fragments in the original order.
- Fragments resolve out-of-store to the repo checkout.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
