### PR TITLE
refactor(zsh): source option.zsh from out-of-store symlink

### DIFF
--- a/nix/programs/zsh/default.nix
+++ b/nix/programs/zsh/default.nix
@@ -1,7 +1,4 @@
-{ pkgs, ... }:
-let
-  optionScript = builtins.readFile ./option.zsh;
-in
+{ config, mkRepoLink, ... }:
 {
   programs.zsh = {
     enable = true;
@@ -22,8 +19,12 @@ in
       C = "| pbcopy";
     };
 
+    # Source option.zsh from an out-of-store symlink so it is editable in place
+    # (a new shell picks up edits — no rebuild). See #70.
     initContent = ''
-      ${optionScript}
+      source ${config.home.homeDirectory}/.config/zsh/option.zsh
     '';
   };
+
+  home.file.".config/zsh/option.zsh".source = mkRepoLink "nix/programs/zsh/option.zsh";
 }


### PR DESCRIPTION
## Summary

Migrates zsh's `option.zsh` to an editable out-of-store symlink (part of #70).

- `option.zsh` is symlinked under `~/.config/zsh` via `mkRepoLink`.
- `programs.zsh.initContent` sources it instead of inlining via `readFile`.
- No self-path dependencies → `source` is behaviorally identical to inlining.

## Verification

- `darwin-rebuild build .#siraken-mbp` succeeds.
- Generated `.zshrc` sources `option.zsh`; the fragment resolves out-of-store to
  the repo checkout.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)
