### PR TITLE
refactor(fish): source fragments from out-of-store symlinks

### DIFF
--- a/nix/programs/fish/default.nix
+++ b/nix/programs/fish/default.nix
@@ -1,8 +1,9 @@
-{ pkgs, ... }:
-let
-  functionsScript = builtins.readFile ./function.fish;
-  completionScript = builtins.readFile ./completion.fish;
-in
+{
+  pkgs,
+  config,
+  mkRepoLink,
+  ...
+}:
 {
   programs.fish = {
     enable = true;
@@ -28,15 +29,19 @@ in
       }
     ];
 
+    # Source the fragments from out-of-store symlinks (same order as before) so
+    # they are editable in place — a new shell picks up edits without a rebuild.
+    # Sourced explicitly rather than via conf.d/ autoload to preserve the
+    # original order/timing. See #70.
     interactiveShellInit = ''
       # Disable greeting
       set fish_greeting
 
       # Custom functions
-      ${functionsScript}
+      source ${config.home.homeDirectory}/.config/fish/function.fish
 
       # Completions
-      ${completionScript}
+      source ${config.home.homeDirectory}/.config/fish/completion.fish
 
       # Conditional aliases
       if type -q bat
@@ -48,5 +53,10 @@ in
         alias lla="ll -a"
       end
     '';
+  };
+
+  home.file = {
+    ".config/fish/function.fish".source = mkRepoLink "nix/programs/fish/function.fish";
+    ".config/fish/completion.fish".source = mkRepoLink "nix/programs/fish/completion.fish";
   };
 }


### PR DESCRIPTION
## Summary

Migrates fish's fragments to editable out-of-store symlinks (part of #70).

- `function.fish` / `completion.fish` are symlinked under `~/.config/fish` via
  `mkRepoLink`.
- `programs.fish.interactiveShellInit` sources them (same order: functions →
  completions) instead of inlining via `readFile`.
- No self-path dependencies. Sourced explicitly rather than relying on `conf.d/`
  autoload, to preserve the original order/timing → behavior identical.

## Verification

- `darwin-rebuild build .#siraken-mbp` succeeds.
- Generated `config.fish` sources both fragments in order; fragments resolve
  out-of-store to the repo checkout.
- fish is imported by mbp/macmini/wsl-ubuntu (disabled on the nixos hosts);
  wsl-ubuntu build is covered by CI.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)
