### PR TITLE
refactor(emacs): load init.el from repo via load-file

### DIFF
--- a/nix/programs/emacs/default.nix
+++ b/nix/programs/emacs/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 {
   programs.emacs = {
     enable = true;
@@ -50,6 +50,11 @@
         doom-themes
       ];
 
-    extraConfig = builtins.readFile ./config/init.el;
+    # Load init.el directly from the repo checkout so it is editable in place
+    # (next emacs start picks up edits — no rebuild). The generated default.el
+    # now loads the repo file instead of inlining it; same load timing. See #70.
+    extraConfig = ''
+      (load-file "${config.home.homeDirectory}/dotfiles/nix/programs/emacs/config/init.el")
+    '';
   };
 }


### PR DESCRIPTION
## Summary

Migrates emacs `init.el` to an editable repo file (part of #70).

- `extraConfig` now `(load-file "…/dotfiles/nix/programs/emacs/config/init.el")`
  instead of inlining the file via `readFile`.
- Same load timing (the generated `default.el` loads it) and same content →
  behavior identical.
- `extraPackages` (Nix-managed) unchanged; `init.el` has no self-path deps.

## Verification

- `darwin-rebuild build .#siraken-mbp` succeeds.
- Generated `extraConfig` is the `load-file` of the repo `init.el`.
- emacs is imported by mbp/macmini/wsl-ubuntu/wsl-nixos; Linux builds via CI.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
