### PR TITLE
refactor(config): externalize static tool configs

### DIFF
--- a/config/bat/config
+++ b/config/bat/config
@@ -1,0 +1,2 @@
+--theme=base16
+--style=numbers,changes

--- a/config/gh-dash/config.yml
+++ b/config/gh-dash/config.yml
@@ -1,0 +1,2 @@
+prSections:
+  - filters: "is:open author:@me"

--- a/config/spotify-player/app.toml
+++ b/config/spotify-player/app.toml
@@ -1,0 +1,43 @@
+theme = "dracula"
+
+client_port = 8080
+playback_format = """
+{status} {track} • {artists}
+{album}
+{metadata}
+"""
+notify_timeout_in_secs = 0
+tracks_playback_limit = 50
+app_refresh_duration_in_ms = 32
+playback_refresh_duration_in_ms = 0
+page_size_in_rows = 20
+play_icon = "▶"
+pause_icon = "▌▌"
+liked_icon = "♥"
+border_type = "Plain"
+progress_bar_type = "Rectangle"
+playback_window_position = "Top"
+cover_img_length = 9
+cover_img_width = 5
+cover_img_scale = 1.0
+playback_window_width = 6
+enable_media_control = false
+enable_streaming = "Always"
+enable_notify = true
+enable_cover_image_cache = true
+default_device = "spotify-player"
+notify_streaming_only = false
+seek_duration_secs = 5
+
+[notify_format]
+summary = "{track} • {artists}"
+body = "{album}"
+
+[device]
+name = "spotify-player"
+device_type = "speaker"
+volume = 70
+bitrate = 320
+audio_cache = false
+normalization = false
+autoplay = false

--- a/nix/programs/bat/default.nix
+++ b/nix/programs/bat/default.nix
@@ -1,11 +1,9 @@
-{ pkgs, ... }:
+{ mkRepoLink, ... }:
 {
-  programs.bat = {
-    enable = true;
+  programs.bat.enable = true;
 
-    config = {
-      theme = "base16";
-      style = "numbers,changes";
-    };
-  };
+  # Static config lives in a repo file linked in place, so it is editable
+  # without a rebuild. The bat module only generates ~/.config/bat/config when
+  # `config` is non-empty, so dropping it leaves the path free to link. See #70.
+  xdg.configFile."bat/config".source = mkRepoLink "config/bat/config";
 }

--- a/nix/programs/gh-dash/default.nix
+++ b/nix/programs/gh-dash/default.nix
@@ -1,11 +1,9 @@
-{ pkgs, ... }:
+{ lib, mkRepoLink, ... }:
 {
-  programs.gh-dash = {
-    enable = true;
-    settings = {
-      prSections = [
-        { filters = "is:open author:@me"; }
-      ];
-    };
-  };
+  programs.gh-dash.enable = true;
+
+  # Static config lives in a repo file linked in place, so it is editable
+  # without a rebuild. The gh-dash module sets config.yml's source
+  # unconditionally, so override it with mkForce to point at the repo. See #70.
+  xdg.configFile."gh-dash/config.yml".source = lib.mkForce (mkRepoLink "config/gh-dash/config.yml");
 }

--- a/nix/programs/spotify-player/default.nix
+++ b/nix/programs/spotify-player/default.nix
@@ -1,53 +1,9 @@
-{ pkgs, ... }:
+{ mkRepoLink, ... }:
 {
-  programs.spotify-player = {
-    enable = true;
-    settings = {
-      theme = "dracula";
+  programs.spotify-player.enable = true;
 
-      client_port = 8080;
-      playback_format = ''
-        {status} {track} • {artists}
-        {album}
-        {metadata}
-      '';
-      notify_timeout_in_secs = 0;
-      tracks_playback_limit = 50;
-      app_refresh_duration_in_ms = 32;
-      playback_refresh_duration_in_ms = 0;
-      page_size_in_rows = 20;
-      play_icon = "▶";
-      pause_icon = "▌▌";
-      liked_icon = "♥";
-      border_type = "Plain";
-      progress_bar_type = "Rectangle";
-      playback_window_position = "Top";
-      cover_img_length = 9;
-      cover_img_width = 5;
-      cover_img_scale = 1.0;
-      playback_window_width = 6;
-      enable_media_control = false;
-      enable_streaming = "Always";
-      enable_notify = true;
-      enable_cover_image_cache = true;
-      default_device = "spotify-player";
-      notify_streaming_only = false;
-      seek_duration_secs = 5;
-
-      notify_format = {
-        summary = "{track} • {artists}";
-        body = "{album}";
-      };
-
-      device = {
-        name = "spotify-player";
-        device_type = "speaker";
-        volume = 70;
-        bitrate = 320;
-        audio_cache = false;
-        normalization = false;
-        autoplay = false;
-      };
-    };
-  };
+  # Static settings live in a repo file linked in place, so they are editable
+  # without a rebuild. The spotify-player module only generates app.toml when
+  # `settings` is non-empty, so dropping it leaves the path free to link. See #70.
+  xdg.configFile."spotify-player/app.toml".source = mkRepoLink "config/spotify-player/app.toml";
 }


### PR DESCRIPTION
## 概要

`bat` / `gh-dash` / `spotify-player` の設定を Nix モジュール内のインライン記述から `config/` 配下の native 設定ファイルへ外出しし、`mkRepoLink`（out-of-store symlink）でリンクします。ghostty / kitty / nano で既に採用している #70 の方針を、設定が完全に静的なツールへ広げるものです。

対象は「小規模かつ Nix 非依存（共通カラー変数の切り出しや store-path 参照を持たない）」なものに限定しています。リビルドなしで編集が即反映されるようになります。

## 変更内容

| ツール | 新規 native ファイル | モジュール変更 |
| --- | --- | --- |
| bat | `config/bat/config` | `config` を削除し `mkRepoLink` でリンク |
| gh-dash | `config/gh-dash/config.yml` | `settings` を削除し `lib.mkForce` で source を上書き |
| spotify-player | `config/spotify-player/app.toml` | `settings` を削除し `mkRepoLink` でリンク |

- `gh-dash` だけ `lib.mkForce` が必要です。home-manager の gh-dash モジュールは `config.yml` を無条件で生成するため、衝突回避に source を強制上書きしています。`bat` / `spotify-player` は `settings` が空なら生成されない（`mkIf (cfg.* != {})`）ため、削除するだけで十分です。

## 検証

- `darwin-rebuild build --flake .#siraken-mbp --impure` → exit 0（ファイル衝突・評価エラーなし）
- ビルド成果物の home-manager-files を確認し、3ファイルとも `~/dotfiles/config/...` を指す out-of-store symlink になっていることを確認
- `nix fmt` → 0 changed

> [!NOTE]
> 検証は build までです。反映は手動で `sudo darwin-rebuild switch --flake .#siraken-mbp --impure` を実行してください。

## 今回見送ったもの

- **lazydocker**: macOS では `~/Library/Application Support/jesseduffield/lazydocker/config.yml` に配置され、外出しに OS 分岐（= Nix 依存）が必要
- **bottom / fastfetch / fzf**: `colors/tokyonight.nix` の共通カラー変数を切り出して使用
- **zellij**: `${pkgs.neovim}/bin/nvim` の store-path 参照と layouts の `.nix` import

🤖 Generated with [Claude Code](https://claude.com/claude-code)
