### PR TITLE
refactor(config): externalize vim extraConfig

### DIFF
--- a/config/vim/vimrc
+++ b/config/vim/vimrc
@@ -1,0 +1,91 @@
+" Static vim config sourced from programs.vim.extraConfig (see #70).
+autocmd!
+
+scriptencoding utf-8
+filetype plugin indent on
+syntax enable
+colorscheme industry
+
+set nocompatible
+
+set signcolumn=yes
+set laststatus=2
+set cmdheight=1
+set showtabline=2
+
+set virtualedit=block
+set wildmenu
+set wildignorecase
+
+set smartindent
+
+set hlsearch
+set incsearch
+
+set noswapfile
+set nobackup
+set encoding=utf-8
+set fileencodings=euc-jp,sjis,latin,utf-8
+set fileformats=unix,dos,mac
+
+set title
+set smarttab
+set ruler
+set cursorline
+set showcmd
+set nowrap
+set backspace=start,eol,indent
+set lazyredraw
+set completeopt=menuone,noinsert
+set scrolloff=10
+set formatoptions+=r
+set langmenu=en_US
+
+" Increment / decrement
+nnoremap + <C-a>
+nnoremap - <C-x>
+
+" Select all
+nnoremap <C-a> gg<S-v>G
+
+" Spit window
+nnoremap ss :split<CR><C-W>w
+nnoremap sv :vsplit<CR><C-w>w
+
+" Move window
+nnoremap <Space> <C-w>w
+noremap sh <C-w>h
+noremap sk <C-w>k
+noremap sj <C-w>j
+noremap sl <C-w>l
+
+" Resize window
+nnoremap <C-w><left> <C-w><
+nnoremap <C-w><right> <C-w>>
+nnoremap <C-w><up> <C-w>+
+nnoremap <C-w><down> <C-w>-
+
+" Close buffer
+nnoremap <C-w>q :bd<CR>
+
+" Use Shift + U as redo
+nnoremap U <C-r>
+
+" Reselect visual block after indents
+xnoremap < <gv
+xnoremap > >gv
+
+" Use Tab, Shift + Tab
+inoremap <S-Tab> <C-d>
+xnoremap <Tab> >gv
+xnoremap <S-Tab> <gv
+
+" Auto close brackets
+inoremap ( ()<Left>
+inoremap { {}<Left>
+inoremap [ []<Left>
+
+" Stay visual mode after formatting
+xnoremap = =gv
+
+let $LANG = 'en_US'

--- a/nix/programs/vim/default.nix
+++ b/nix/programs/vim/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 {
   imports = [
     ./ai
@@ -400,97 +400,9 @@
       undofile = false;
     };
 
-    extraConfig = ''
-      autocmd!
-
-      scriptencoding utf-8
-      filetype plugin indent on
-      syntax enable
-      colorscheme industry
-
-      set nocompatible
-
-      set signcolumn=yes
-      set laststatus=2
-      set cmdheight=1
-      set showtabline=2
-
-      set virtualedit=block
-      set wildmenu
-      set wildignorecase
-
-      set smartindent
-
-      set hlsearch
-      set incsearch
-
-      set noswapfile
-      set nobackup
-      set encoding=utf-8
-      set fileencodings=euc-jp,sjis,latin,utf-8
-      set fileformats=unix,dos,mac
-
-      set title
-      set smarttab
-      set ruler
-      set cursorline
-      set showcmd
-      set nowrap
-      set backspace=start,eol,indent
-      set lazyredraw
-      set completeopt=menuone,noinsert
-      set scrolloff=10
-      set formatoptions+=r
-      set langmenu=en_US
-
-      " Increment / decrement
-      nnoremap + <C-a>
-      nnoremap - <C-x>
-
-      " Select all
-      nnoremap <C-a> gg<S-v>G
-
-      " Spit window
-      nnoremap ss :split<CR><C-W>w
-      nnoremap sv :vsplit<CR><C-w>w
-
-      " Move window
-      nnoremap <Space> <C-w>w
-      noremap sh <C-w>h
-      noremap sk <C-w>k
-      noremap sj <C-w>j
-      noremap sl <C-w>l
-
-      " Resize window
-      nnoremap <C-w><left> <C-w><
-      nnoremap <C-w><right> <C-w>>
-      nnoremap <C-w><up> <C-w>+
-      nnoremap <C-w><down> <C-w>-
-
-      " Close buffer
-      nnoremap <C-w>q :bd<CR>
-
-      " Use Shift + U as redo
-      nnoremap U <C-r>
-
-      " Reselect visual block after indents
-      xnoremap < <gv
-      xnoremap > >gv
-
-      " Use Tab, Shift + Tab
-      inoremap <S-Tab> <C-d>
-      xnoremap <Tab> >gv
-      xnoremap <S-Tab> <gv
-
-      " Auto close brackets
-      inoremap ( ()<Left>
-      inoremap { {}<Left>
-      inoremap [ []<Left>
-
-      " Stay visual mode after formatting
-      xnoremap = =gv
-
-      let $LANG = 'en_US'
-    '';
+    # Static vim config lives in a repo file sourced directly by vim, so it
+    # is editable in place without a rebuild. home-manager still owns the
+    # generated vimrc (settings, plugins). See #70.
+    extraConfig = "source ${config.home.homeDirectory}/dotfiles/config/vim/vimrc";
   };
 }


### PR DESCRIPTION
## 概要

静的設定外出しの **Phase 2**。`programs.vim.extraConfig` の freeform な vim script を `config/vim/vimrc` へ外出しし、`source` ディレクティブで直接読み込みます（kitty と同じ #70 の include 方式、#98 / #99 の続き）。

スクリプトは完全に静的（Nix 補間なし）なので、キーマップや autocmd をリビルドなしで編集できるようになります。

## 変更内容

| 対象 | 変更 |
| --- | --- |
| `config/vim/vimrc`（新規） | extraConfig の vim script を移設 |
| `nix/programs/vim/default.nix` | 引数に `config` を追加。`extraConfig` を `source ${config.home.homeDirectory}/dotfiles/config/vim/vimrc` の1行に置換 |

- `programs.vim.settings`（tabstop / 行番号 / background など typed 設定）と **nixvim（Neovim）設定は Nix 管理のまま**です。home-manager が生成する vimrc は引き続き settings・plugins を所有し、末尾で repo の vimrc を source します（ghostty が font-size を Nix に残したのと同じ切り分け）。
- mkRepoLink ではなく、kitty/ghostty と同様にディレクティブ内で repo の絶対パスを直接参照します（vim が起動時に source）。

## 検証

- `darwin-rebuild build --flake .#siraken-mbp --impure` → exit 0
- 生成された vimrc を確認し、`settings` ブロックの直後が `source /Users/siraken/dotfiles/config/vim/vimrc` になっていることを確認（順序保持）

> [!NOTE]
> 検証は build までです。反映は手動で `sudo darwin-rebuild switch --flake .#siraken-mbp --impure` を実行してください。

## 補足: これで「クリーンな静的外出し」は一区切り

残るインライン設定（helix / yazi / bottom / fzf / sketchybar / zellij / aerospace）はいずれも共通カラーパレット（`colors/tokyonight.nix`）や `pkgs` の store パスに依存しており、外出しは単一ソース管理を失う／OS 分岐が必要になるため、現状維持が妥当です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
