### PR TITLE
fix(vim): rename conform option to conform-nvim

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781305496,
-        "narHash": "sha256-g8Vv4Qfc7n+lgov97REu3X6BeJtvYY0hlSUZR1GrGQQ=",
+        "lastModified": 1781365335,
+        "narHash": "sha256-zqDBhXMzfbdlO7F2bGHe7MOtB3xngd/+4ieMHDC+ZXo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c87a39aa979acc4848016d2220c6238390d84779",
+        "rev": "5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781330261,
-        "narHash": "sha256-2fFAGel2VVXr5mwrTXldqXva2ng3T3HHxyuBKRIxauI=",
+        "lastModified": 1781417226,
+        "narHash": "sha256-AYNYZPqm8XKQSAniBCQcIAqZjkyWABO3qlcdGgs+dJk=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "24ec6b7b1ddf8896ac8df3b65dc564575e0a1928",
+        "rev": "02eaebc50f55ee11ce9bc938bcbc5962beaf54a6",
         "type": "github"
       },
       "original": {
@@ -293,11 +293,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780816331,
-        "narHash": "sha256-0BYqs8yKWkOz2Q7+SP18N5E5gmDKSo6LSxIVIa0wWes=",
+        "lastModified": 1781422160,
+        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "1a2ea89c917781e88508d9fd2b507f2d2a0e173c",
+        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
         "type": "github"
       },
       "original": {
@@ -356,11 +356,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781268102,
-        "narHash": "sha256-Zn5KTggEmUB3lXn/ccERNcBdddE6IaOFber9dWViWDg=",
+        "lastModified": 1781359544,
+        "narHash": "sha256-iUuzKQcyXvopYDDzFpMK5eQKP3WIJExYny2kJtbgUcE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "49a4bd0573c376468dd7996ddb6f9fa31d8c4d97",
+        "rev": "9f11f828c213641c2369a9f1fa31fe31557e3156",
         "type": "github"
       },
       "original": {
@@ -442,11 +442,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1781287460,
-        "narHash": "sha256-9hXtN4my7eBqHRVQ/t6FQZ4YqZ1KG6SsKSG4Hdtr+i0=",
+        "lastModified": 1781388258,
+        "narHash": "sha256-Kx1zxra9sZ215H3OiWUfkulu8N2v3iu19wqlzpD/Ac0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "f2029d9a26266eb67f46b0c79bd0a3713839a57a",
+        "rev": "e3c908fdf6dff268b04ffb6758bcfc7c018489b9",
         "type": "github"
       },
       "original": {

--- a/nix/programs/vim/coding/default.nix
+++ b/nix/programs/vim/coding/default.nix
@@ -4,7 +4,7 @@
     plugins = {
       comment.enable = true;
 
-      conform = {
+      conform-nvim = {
         enable = true;
         settings = {
           formatters_by_ft = {


### PR DESCRIPTION
## 背景

スケジュール実行の **Flake Updater** ワークフローが 2026-06-13 21:31 UTC 以降ずっと失敗していた。

```
error: The option `programs.nixvim.plugins.conform' does not exist.
- In `.../nix/programs/vim/coding'
```

## 原因

nixvim が by-name モジュール化に伴い、フォーマッタプラグインのオプションを `plugins.conform` → `plugins.conform-nvim` にリネームした（`moduleName` は `conform` のままなので Lua の `require("conform")` は変更不要）。`nix flake update` が新しい nixvim を引いた結果、`nix/programs/vim/coding/default.nix` の `plugins.conform` が「存在しないオプション」となり `nix flake check` が落ちた。

なお `nix flake check` 失敗で `git push` ステップに到達しないため、更新後の壊れた `flake.lock` は main に push されていない。

## 変更

- `nix/programs/vim/coding/default.nix`: `conform` → `conform-nvim`
- `flake.lock`: nixvim を `f2029d9a` → `e3c908fd`（リネームを含む版）ほか全 input を更新

リネーム後の名前 `conform-nvim` は更新後の nixvim にのみ存在するため、オプション変更と `flake.lock` 更新はセットで行う必要がある。

## 検証

- `nix flake check --impure`（aarch64-darwin）: `all checks passed!`
- `wsl-nixos` / `wsl-ubuntu`（x86_64-linux）: drvPath の eval 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)
