### PR TITLE
ci(nix): evaluate every profile and gate lock updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,11 @@
 name: CI
 on:
+  # Only main. A branch also covered by a push trigger runs this workflow twice
+  # while it has an open pull request; push a branch and open a draft PR to try
+  # CI on it instead.
   push:
     branches:
       - main
-      - ci/*
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,5 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: DeterminateSystems/determinate-nix-action@131015bad844610e5e6300f8a143bf625d3e74f4 # v3.17.0
+      # Builds checks.x86_64-linux: treefmt, pre-commit, and eval-all — the last
+      # one forces a pure evaluation of all five profiles (macOS included).
+      # The profiles themselves are not built here: one system closure is
+      # 12.4 GiB and a GitHub-hosted runner only has 14 GB of disk.
       - name: Run nix flake check
-        run: nix flake check
+        run: nix flake check --print-build-logs

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -1,11 +1,13 @@
 name: Flake Updater
 on:
   schedule:
-    # Every 6 hours at 00:00, 06:00, 12:00, 18:00 JST (15:00, 21:00, 03:00, 09:00 UTC)
-    - cron: "0 3,9,15,21 * * *"
+    # 06:00 JST daily (21:00 UTC). nixpkgs-unstable only advances a few times a
+    # week, so the previous 6-hourly schedule was mostly empty runs.
+    - cron: "0 21 * * *"
   workflow_dispatch:
 permissions:
   contents: write
+  pull-requests: write
 jobs:
   update:
     name: Update Flake
@@ -18,8 +20,44 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - uses: DeterminateSystems/determinate-nix-action@131015bad844610e5e6300f8a143bf625d3e74f4 # v3.17.0
       - name: Update flake.lock
-        run: nix flake update --commit-lock-file
+        id: update
+        run: |
+          nix flake update 2>&1 | tee /tmp/flake-update.log
+          if git diff --quiet -- flake.lock; then
+            echo "changed=false" >>"$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >>"$GITHUB_OUTPUT"
+          fi
+      # This is the validation for the update: a pull request opened with
+      # GITHUB_TOKEN does not start a workflow run, so CI will not re-run on the
+      # PR itself. It runs again on main once the PR is merged by a human.
       - name: Run nix flake check
-        run: nix flake check
-      - name: Push changes
-        run: git push
+        if: steps.update.outputs.changed == 'true'
+        run: nix flake check --print-build-logs
+      - name: Open pull request
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch=flake-update
+          git switch -c "$branch"
+          git commit -am "flake.lock: Update"
+          git push --force -u origin "$branch"
+
+          # The backticks below are markdown, not command substitution.
+          # shellcheck disable=SC2016
+          {
+            printf 'Automated `nix flake update`.\n\n```\n'
+            cat /tmp/flake-update.log
+            printf '```\n\n'
+            printf '`nix flake check` passed in the updater job (treefmt, pre-commit, and a pure evaluation of all five profiles).\n'
+            printf 'A pull request opened with `GITHUB_TOKEN` does not start a workflow run, so CI runs again on `main` after this is merged.\n'
+          } >/tmp/pr-body.md
+
+          existing=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --body-file /tmp/pr-body.md
+          else
+            gh pr create --base main --head "$branch" \
+              --title "flake.lock: Update" --body-file /tmp/pr-body.md
+          fi

--- a/flake.nix
+++ b/flake.nix
@@ -156,6 +156,33 @@
               pkgs.nixpkgs-fmt
             ];
           };
+
+          checks = {
+            # Forces a full, pure evaluation of every configuration in this
+            # flake. Producing the derivation paths is what does the work; the
+            # string context is discarded so building this check never builds a
+            # profile. It costs seconds and runs on every system, so a broken
+            # module or a typo in any host fails CI even though the runner
+            # cannot build the profiles themselves.
+            eval-all = pkgs.writeText "eval-all-configurations" (
+              nixpkgs.lib.concatMapStringsSep "\n" builtins.unsafeDiscardStringContext [
+                self.darwinConfigurations.siraken-mbp.system.drvPath
+                self.darwinConfigurations.siraken-macmini.system.drvPath
+                self.nixosConfigurations.nixos-vm.config.system.build.toplevel.drvPath
+                self.nixosConfigurations.wsl-nixos.config.system.build.toplevel.drvPath
+                self.homeConfigurations.wsl-ubuntu.activationPackage.drvPath
+              ]
+            );
+          }
+          // nixpkgs.lib.optionalAttrs (system == "aarch64-darwin") {
+            # Real system builds. A GitHub-hosted runner has 14 GB of disk and
+            # one system closure is 12.4 GiB, so these only ever run locally
+            # (`nix flake check` on the Mac); CI stops at `eval-all`. Once the
+            # package set is split per role, or a personal binary cache exists,
+            # this can move into CI.
+            siraken-mbp = self.darwinConfigurations.siraken-mbp.system;
+            siraken-macmini = self.darwinConfigurations.siraken-macmini.system;
+          };
         }
         // nixpkgs.lib.optionalAttrs (system == "aarch64-darwin") {
           apps =
@@ -173,11 +200,6 @@
                 nix store gc
               '';
             };
-
-          checks = {
-            siraken-mbp = self.darwinConfigurations.siraken-mbp.system;
-            siraken-macmini = self.darwinConfigurations.siraken-macmini.system;
-          };
         };
 
       flake = {


### PR DESCRIPTION
## Summary

Two gaps this closes:

1. **CI verified nothing about the profiles.** `checks.aarch64-darwin.{siraken-mbp,siraken-macmini}` were declared, but the runner is `ubuntu-latest`, so the Linux check set was only `[pre-commit, treefmt]`. A broken module in any host reached `main` unnoticed.
2. **The updater pushed lock bumps straight to `main`** behind that same check, four times a day.

## What changed

### `checks.<system>.eval-all`

```nix
eval-all = pkgs.writeText "eval-all-configurations" (
  nixpkgs.lib.concatMapStringsSep "\n" builtins.unsafeDiscardStringContext [
    self.darwinConfigurations.siraken-mbp.system.drvPath
    ...
  ]
);
```

Producing those `drvPath` strings is what does the work: it forces a **pure evaluation of all five profiles**, on any system. The string context is discarded, so building the check builds one tiny text file instead of a profile.

Measured: `nix build .#checks.aarch64-darwin.eval-all` → `this derivation will be built: 1`, 0.7s.

Linux check set goes from `[pre-commit, treefmt]` to `[eval-all, pre-commit, treefmt]`.

### Updater → daily pull request

Reuses a `flake-update` branch, edits the existing PR body if one is open. Schedule drops from 6-hourly to daily (06:00 JST) — `nixpkgs-unstable` only advances a few times a week.

It still runs `nix flake check` **in the job**, because a PR opened with `GITHUB_TOKEN` does not start a workflow run ([documented behaviour](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow)). The result is stated in the PR body, and CI runs again on `main` after a human merges.

## Deliberately not done: building the systems on a macOS runner

The original plan was a `macos-15` job building the darwin systems. It does not fit:

| | Size |
| --- | --- |
| GitHub-hosted runner disk (ubuntu **and** macOS arm64, public repo) | 14 GB |
| One system closure (`siraken-mbp`) | 12.4 GiB |

`checks.aarch64-darwin.{siraken-mbp,siraken-macmini}` are kept, so a local `nix flake check` on the Mac still builds both. Moving them into CI needs either the per-role package split or a personal binary cache first — both already on the list.

## Verification

| Check | Result |
| --- | --- |
| `nix flake check` locally (darwin) | `all checks passed!` — both systems built |
| `nix eval .#checks.x86_64-linux --apply builtins.attrNames` | `[ "eval-all" "pre-commit" "treefmt" ]` |
| `eval-all` build cost | 1 derivation, 0.7s, no profile built |
| `eval-all` contents | 5 drvPaths, one per profile |
| `actionlint` (incl. shellcheck) on both workflows | exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
