### PR TITLE
feat(sketchybar): per-display spaces and new items

### DIFF
--- a/nix/services/darwin/aerospace.nix
+++ b/nix/services/darwin/aerospace.nix
@@ -95,6 +95,9 @@ let
     run = "layout floating";
   };
 
+  # Sketchybar のアイテム生成と共有するワークスペース一覧
+  workspaces = import ./workspaces.nix;
+
   # ウィンドウを別ワークスペースへ移してもフォーカス中のワークスペースは変わらないため
   # exec-on-workspace-change は発火しない。Sketchybar 側のアプリアイコン表示を
   # 追従させるために、移動系のバインドから明示的にイベントを投げる。
@@ -121,8 +124,11 @@ in
       default-root-container-orientation = "auto";
 
       automatically-unhide-macos-hidden-apps = false;
-      on-focus-changed = [ ];
-      on-focused-monitor-changed = [ ];
+
+      # ウィンドウの開閉はフォーカス移動を伴うので、これを拾えば Sketchybar の
+      # アプリアイコン表示が追従する。定期ポーリングの保険を持たずに済む。
+      on-focus-changed = [ sketchybarRefresh ];
+      on-focused-monitor-changed = [ sketchybarRefresh ];
 
       # Gaps and padding
       gaps = {
@@ -245,15 +251,7 @@ in
         }
       ];
 
-      persistent-workspaces = [
-        "1"
-        "2"
-        "3"
-        "4"
-        "5"
-        "6"
-        "7"
-      ];
+      persistent-workspaces = workspaces;
 
       workspace-to-monitor-force-assignment = { };
 

--- a/nix/services/darwin/sketchybar/default.nix
+++ b/nix/services/darwin/sketchybar/default.nix
@@ -23,11 +23,16 @@ let
   # ワークスペースのアプリアイコン用フォント（`:app_name:` のリガチャで描画される）
   appFont = pkgs.sketchybar-app-font;
 
+  # AeroSpace の persistent-workspaces と共有するワークスペース一覧。
+  # 実行時に aerospace へ問い合わせるとウィンドウがあるものしか拾えないため、
+  # アイテムの集合はこちらから決める。
+  workspaces = import ../workspaces.nix;
+
   # 全プラグインの先頭に差し込む共通定義。
   # 色は Nix 側の 1 箇所で管理し、PATH も明示して起動環境に依存しないようにする。
   # (GNU 版で挙動が変わる grep / date などを拾わないよう、システムのパスのみを足している)
   prelude = ''
-    export PATH="${pkgs.sketchybar}/bin:${pkgs.aerospace}/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    export PATH="${pkgs.sketchybar}/bin:${pkgs.aerospace}/bin:${pkgs.switchaudio-osx}/bin:${pkgs.gh}/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
     COLOR_TRANSPARENT=${colors.transparent}
     COLOR_BG=${colors.background}
@@ -61,9 +66,18 @@ let
   batteryPlugin = mkPlugin { name = "battery.sh"; };
   batteryClickPlugin = mkPlugin { name = "battery_click.sh"; };
   volumePlugin = mkPlugin { name = "volume.sh"; };
+  volumeClickPlugin = mkPlugin { name = "volume_click.sh"; };
+  volumeSliderPlugin = mkPlugin { name = "volume_slider.sh"; };
+  volumeDevicePlugin = mkPlugin { name = "volume_device.sh"; };
   frontAppPlugin = mkPlugin { name = "front_app.sh"; };
   mediaPlugin = mkPlugin { name = "media.sh"; };
   mediaClickPlugin = mkPlugin { name = "media_click.sh"; };
+  mediaControlPlugin = mkPlugin { name = "media_control.sh"; };
+  inputSourcePlugin = mkPlugin { name = "input_source.sh"; };
+  cpuPlugin = mkPlugin { name = "cpu.sh"; };
+  memoryPlugin = mkPlugin { name = "memory.sh"; };
+  githubPlugin = mkPlugin { name = "github.sh"; };
+  githubClickPlugin = mkPlugin { name = "github_click.sh"; };
 in
 {
   services.sketchybar = {
@@ -133,7 +147,7 @@ in
 
       SPACE_SIDS=()
       SPACE_IDS=()
-      for sid in $(${aerospace} list-workspaces --all); do
+      for sid in ${lib.concatStringsSep " " workspaces}; do
         sketchybar --add item space.$sid left \
           --set space.$sid \
             background.color=${colors.transparent} \
@@ -164,12 +178,12 @@ in
           background.drawing=on
 
       # ワークスペース表示は 1 本のドライバでまとめて更新する（自身は描画しない）。
-      # update_freq は取りこぼし用の保険で、通常はイベントで更新される。
+      # AeroSpace 側の on-focus-changed / on-focused-monitor-changed からも
+      # aerospace_workspace_change が飛ぶため、定期ポーリングは持たせていない。
       sketchybar --add item spaces_watcher left \
         --set spaces_watcher \
           drawing=off \
           updates=on \
-          update_freq=15 \
           script="${spacesPlugin} ''${SPACE_IDS[*]}" \
         --subscribe spaces_watcher \
           aerospace_workspace_change \
@@ -208,9 +222,38 @@ in
         label.font="Hack Nerd Font:bold:12.0"
       sketchybar --set clock.popup.1 label.color=${colors.muted}
 
+      # 音量: バー上のスクロールで上下、クリックで popup（スライダーと出力デバイス）
+      sketchybar --add event volume_update
       sketchybar --add item volume right \
-        --set volume "''${island[@]}" script="${volumePlugin}" \
-        --subscribe volume volume_change
+        --set volume \
+          "''${island[@]}" \
+          "''${popup_style[@]}" \
+          script="${volumePlugin}" \
+          click_script="${volumeClickPlugin} ${volumeDevicePlugin}" \
+        --subscribe volume volume_change volume_update mouse.scrolled mouse.exited.global
+
+      sketchybar --add slider volume.popup.slider popup.volume 130 \
+        --set volume.popup.slider \
+          script="${volumeSliderPlugin}" \
+          icon.drawing=off \
+          label.drawing=off \
+          background.drawing=off \
+          padding_left=12 \
+          padding_right=12 \
+          slider.background.height=6 \
+          slider.background.corner_radius=3 \
+          slider.background.color=${colors.surface} \
+          slider.highlight_color=${colors.pink} \
+          slider.knob="●" \
+          slider.knob.font="Hack Nerd Font:Bold:14.0" \
+          slider.knob.color=${colors.white} \
+        --subscribe volume.popup.slider mouse.clicked
+
+      # 出力デバイスの選択肢。数は接続状況で変わるのでスロットを固定数用意しておく。
+      for i in ${lib.concatStringsSep " " (map toString (lib.range 0 15))}; do
+        sketchybar --add item volume.popup.device.$i popup.volume \
+          --set volume.popup.device.$i "''${popup_item[@]}" drawing=off
+      done
 
       sketchybar --add item battery right \
         --set battery \
@@ -230,17 +273,77 @@ in
       sketchybar --add item battery.popup.health popup.battery \
         --set battery.popup.health "''${popup_item[@]}" icon=󰋑 icon.color=${colors.pink}
 
-      # Spotify と Apple Music を 1 つのアイテムに統合し、クリック時は即時更新する
+      # 入力ソース。専用イベントは無いが、システムが配信する通知を購読できるので
+      # ポーリングせずに済む。
+      sketchybar --add event input_source_change AppleSelectedInputSourcesChangedNotification
+      sketchybar --add item input_source right \
+        --set input_source "''${island[@]}" script="${inputSourcePlugin}" \
+        --subscribe input_source input_source_change
+
+      # GitHub の未読通知。ネットワークを叩くので間隔は長め、0 件なら隠す。
+      sketchybar --add event github_update
+      sketchybar --add item github right \
+        --set github \
+          "''${island[@]}" \
+          update_freq=300 \
+          script="${githubPlugin}" \
+          click_script="${githubClickPlugin}" \
+        --subscribe github github_update
+
+      sketchybar --add item memory right \
+        --set memory \
+          "''${island[@]}" \
+          update_freq=5 \
+          script="${memoryPlugin}"
+
+      sketchybar --add graph cpu right 40 \
+        --set cpu \
+          "''${island[@]}" \
+          update_freq=3 \
+          script="${cpuPlugin}" \
+          icon=󰍛 \
+          graph.line_width=2 \
+          label.padding_left=6
+
+      # Spotify と Apple Music を 1 つのアイテムに統合し、操作時は即時更新する。
+      # 左クリックで再生/一時停止、右クリックで曲送りの popup を開く。
       sketchybar --add event media_update
       sketchybar --add item media right \
         --set media \
           "''${island[@]}" \
+          "''${popup_style[@]}" \
+          popup.horizontal=on \
           update_freq=3 \
           scroll_texts=on \
           label.max_chars=28 \
           script="${mediaPlugin}" \
-          click_script="${mediaClickPlugin}" \
-        --subscribe media media_update
+          click_script="${mediaClickPlugin} ${mediaControlPlugin}" \
+        --subscribe media media_update mouse.exited.global
+
+      sketchybar --add item media.popup.prev popup.media \
+        --set media.popup.prev \
+          "''${popup_item[@]}" \
+          icon=󰒮 \
+          icon.padding_left=14 \
+          icon.padding_right=14 \
+          label.drawing=off \
+          click_script="${mediaControlPlugin} previous"
+      sketchybar --add item media.popup.play popup.media \
+        --set media.popup.play \
+          "''${popup_item[@]}" \
+          icon=󰐊 \
+          icon.padding_left=14 \
+          icon.padding_right=14 \
+          label.drawing=off \
+          click_script="${mediaControlPlugin} toggle"
+      sketchybar --add item media.popup.next popup.media \
+        --set media.popup.next \
+          "''${popup_item[@]}" \
+          icon=󰒭 \
+          icon.padding_left=14 \
+          icon.padding_right=14 \
+          label.drawing=off \
+          click_script="${mediaControlPlugin} next"
 
       sketchybar --update
       sketchybar --trigger aerospace_workspace_change

--- a/nix/services/darwin/sketchybar/plugins/cpu.sh
+++ b/nix/services/darwin/sketchybar/plugins/cpu.sh
@@ -1,0 +1,41 @@
+# CPU 使用率を graph に流し込む。
+#
+# ps の %cpu は各プロセスの減衰平均なので厳密な瞬間値ではないが、
+# top -l 1 は実測で 1.3 秒かかるため、軽さを優先してこちらを使う。
+CORES="$(sysctl -n hw.ncpu 2>/dev/null)"
+case "$CORES" in
+'' | *[!0-9]*) exit 0 ;;
+esac
+[ "$CORES" -gt 0 ] || exit 0
+
+TOTAL="$(ps -A -o %cpu | awk '{ s += $1 } END { printf "%.0f", s }')"
+case "$TOTAL" in
+'' | *[!0-9]*) exit 0 ;;
+esac
+
+USAGE=$((TOTAL / CORES))
+[ "$USAGE" -gt 100 ] && USAGE=100
+
+if [ "$USAGE" -ge 80 ]; then
+  COLOR="$COLOR_PINK"
+elif [ "$USAGE" -ge 50 ]; then
+  COLOR="$COLOR_ORANGE"
+else
+  COLOR="$COLOR_GREEN"
+fi
+
+# graph は 0.0-1.0 でデータ点を受ける
+RATIO="$(awk -v u="$USAGE" 'BEGIN { printf "%.3f", u / 100 }')"
+
+# 塗りつぶしは線と同じ色を薄くしたもの（色は 0xffRRGGBB 形式）
+FILL="0x33${COLOR#0xff}"
+
+sketchybar --push "$NAME" "$RATIO" \
+  --set "$NAME" \
+  icon.color="$COLOR" \
+  label="$USAGE%" \
+  label.color="$COLOR" \
+  graph.color="$COLOR" \
+  graph.fill_color="$FILL" \
+  background.color="$COLOR_BG" \
+  background.drawing=on

--- a/nix/services/darwin/sketchybar/plugins/github.sh
+++ b/nix/services/darwin/sketchybar/plugins/github.sh
@@ -1,0 +1,26 @@
+# 未読の GitHub 通知件数を表示する。
+#
+# ネットワークを叩くので更新間隔は長め。通知が無いときと、認証切れなどで
+# 件数が取れなかったときはアイテムごと隠す。
+COUNT="$(gh api notifications --jq 'length' 2>/dev/null)"
+
+case "$COUNT" in
+'' | *[!0-9]*)
+  sketchybar --set "$NAME" drawing=off
+  exit 0
+  ;;
+esac
+
+if [ "$COUNT" -eq 0 ]; then
+  sketchybar --set "$NAME" drawing=off
+  exit 0
+fi
+
+sketchybar --set "$NAME" \
+  drawing=on \
+  icon="" \
+  icon.color="$COLOR_PURPLE" \
+  label="$COUNT" \
+  label.color="$COLOR_PURPLE" \
+  background.color="$COLOR_BG" \
+  background.drawing=on

--- a/nix/services/darwin/sketchybar/plugins/github_click.sh
+++ b/nix/services/darwin/sketchybar/plugins/github_click.sh
@@ -1,0 +1,5 @@
+# 通知一覧をブラウザで開いてから、既読になった件数を取り込み直す
+open "https://github.com/notifications"
+
+sleep 1
+sketchybar --trigger github_update

--- a/nix/services/darwin/sketchybar/plugins/input_source.sh
+++ b/nix/services/darwin/sketchybar/plugins/input_source.sh
@@ -1,0 +1,26 @@
+# 現在の入力ソースを表示する。
+#
+# 入力ソースの変更には専用のイベントが無いが、システムが
+# AppleSelectedInputSourcesChangedNotification を配信しているので、
+# sketchybar の --add event で購読しイベント駆動にしている（ポーリング不要）。
+SOURCE="$(defaults read "$HOME/Library/Preferences/com.apple.HIToolbox.plist" AppleSelectedInputSources 2>/dev/null | tr -d ' \n')"
+
+case "$SOURCE" in
+*.Japanese*)
+  LABEL="JA"
+  COLOR="$COLOR_GREEN"
+  ;;
+*)
+  # ABC などのキーボードレイアウトと、ことえりの英字モード
+  LABEL="EN"
+  COLOR="$COLOR_WHITE"
+  ;;
+esac
+
+sketchybar --set "$NAME" \
+  icon="󰌌" \
+  icon.color="$COLOR" \
+  label="$LABEL" \
+  label.color="$COLOR" \
+  background.color="$COLOR_BG" \
+  background.drawing=on

--- a/nix/services/darwin/sketchybar/plugins/media.sh
+++ b/nix/services/darwin/sketchybar/plugins/media.sh
@@ -1,3 +1,9 @@
+# バーの外にカーソルが出たら popup を閉じる
+if [ "$SENDER" = "mouse.exited.global" ]; then
+  sketchybar --set "$NAME" popup.drawing=off
+  exit 0
+fi
+
 # Spotify と Apple Music を 1 回の osascript でまとめて問い合わせる。
 #
 # - `application "X" is running` はアプリを起動させずに状態を確認できる安全な判定方法
@@ -77,9 +83,11 @@ esac
 if [ "$STATE" = "playing" ]; then
   ICON_COLOR="$BRAND_COLOR"
   LABEL_COLOR="$COLOR_WHITE"
+  PLAY_ICON="󰏤"
 else
   ICON_COLOR="$COLOR_MUTED"
   LABEL_COLOR="$COLOR_MUTED"
+  PLAY_ICON="󰐊"
 fi
 
 # 長い曲名の切り詰めは label.max_chars + scroll_texts に任せる。
@@ -100,4 +108,5 @@ sketchybar --set "$NAME" \
   label="$LABEL" \
   label.color="$LABEL_COLOR" \
   background.color="$COLOR_BG" \
-  background.drawing=on
+  background.drawing=on \
+  --set media.popup.play icon="$PLAY_ICON"

--- a/nix/services/darwin/sketchybar/plugins/media_click.sh
+++ b/nix/services/darwin/sketchybar/plugins/media_click.sh
@@ -1,36 +1,14 @@
-# 再生/一時停止をトグルする。
+# バーのメディアアイテムのクリック操作。
 #
-# - 再生中のアプリがあればそれを止める。無ければ起動中のアプリを再生する（Spotify 優先）
-# - 起動していないアプリは触らない（自動起動を防止）
-osascript <<'APPLESCRIPT' 2>/dev/null
-with timeout of 5 seconds
-	if application "Spotify" is running then
-		tell application "Spotify"
-			if player state is playing then
-				pause
-				return
-			end if
-		end tell
-	end if
-	if application "Music" is running then
-		tell application "Music"
-			if player state is playing then
-				pause
-				return
-			end if
-		end tell
-	end if
-	if application "Spotify" is running then
-		tell application "Spotify" to play
-		return
-	end if
-	if application "Music" is running then
-		tell application "Music" to play
-	end if
-end timeout
-APPLESCRIPT
+# - 左クリック: 再生 / 一時停止
+# - 右クリック: popup（前へ・再生・次へ）の開閉
+#
+# $BUTTON が渡らない環境でも左クリック相当の動作に落ちるようにしている。
+CONTROL_PLUGIN="$1"
 
-# アプリ側の状態が切り替わるのを待ってから再描画する
-# （ポーリング間隔を伸ばしているため、クリック時は明示的に更新する）
-sleep 0.2
-sketchybar --trigger media_update
+if [ "$BUTTON" = "right" ]; then
+  sketchybar --set "$NAME" popup.drawing=toggle
+  exit 0
+fi
+
+"$CONTROL_PLUGIN" toggle

--- a/nix/services/darwin/sketchybar/plugins/media_control.sh
+++ b/nix/services/darwin/sketchybar/plugins/media_control.sh
@@ -1,0 +1,43 @@
+# 再生中のアプリに操作を送る。
+#
+# - 再生中のものがあればそれを、無ければ起動中のもの（Spotify 優先）を対象にする
+# - 起動していないアプリは触らない（自動起動を防止）
+case "$1" in
+previous) COMMAND="previous track" ;;
+next) COMMAND="next track" ;;
+toggle) COMMAND="playpause" ;;
+*) exit 0 ;;
+esac
+
+osascript <<APPLESCRIPT 2>/dev/null
+with timeout of 5 seconds
+	if application "Spotify" is running then
+		tell application "Spotify"
+			if player state is playing then
+				$COMMAND
+				return
+			end if
+		end tell
+	end if
+	if application "Music" is running then
+		tell application "Music"
+			if player state is playing then
+				$COMMAND
+				return
+			end if
+		end tell
+	end if
+	if application "Spotify" is running then
+		tell application "Spotify" to $COMMAND
+		return
+	end if
+	if application "Music" is running then
+		tell application "Music" to $COMMAND
+	end if
+end timeout
+APPLESCRIPT
+
+# アプリ側の状態が切り替わるのを待ってから再描画する
+# （ポーリング間隔を伸ばしているため、操作時は明示的に更新する）
+sleep 0.2
+sketchybar --trigger media_update

--- a/nix/services/darwin/sketchybar/plugins/memory.sh
+++ b/nix/services/darwin/sketchybar/plugins/memory.sh
@@ -1,0 +1,25 @@
+# メモリ使用率を表示する。
+# memory_pressure は空き割合を返すので使用率に直す（実測 9ms と軽い）。
+FREE="$(memory_pressure 2>/dev/null | awk -F': ' '/free percentage/ { gsub(/[^0-9]/, "", $2); print $2; exit }')"
+case "$FREE" in
+'' | *[!0-9]*) exit 0 ;;
+esac
+
+USED=$((100 - FREE))
+[ "$USED" -lt 0 ] && USED=0
+
+if [ "$USED" -ge 85 ]; then
+  COLOR="$COLOR_PINK"
+elif [ "$USED" -ge 65 ]; then
+  COLOR="$COLOR_ORANGE"
+else
+  COLOR="$COLOR_GREEN"
+fi
+
+sketchybar --set "$NAME" \
+  icon="󰘚" \
+  icon.color="$COLOR" \
+  label="$USED%" \
+  label.color="$COLOR" \
+  background.color="$COLOR_BG" \
+  background.drawing=on

--- a/nix/services/darwin/sketchybar/plugins/spaces.sh
+++ b/nix/services/darwin/sketchybar/plugins/spaces.sh
@@ -2,13 +2,16 @@
 #
 # 引数には設定時に確定したワークスペース ID（アイテム space.<id> と 1:1 対応）を渡す。
 # ワークスペースごとに個別スクリプトを走らせず、この 1 本で全アイテムを更新することで
-# aerospace CLI の呼び出しを 3 回に抑えている。
+# aerospace CLI の呼び出しを 4 回に抑えている。
 
 # aerospace_workspace_change から渡る FOCUSED_WORKSPACE があればそれを使う
 FOCUSED="${FOCUSED_WORKSPACE:-$(aerospace list-workspaces --focused)}"
 # 各モニタで表示中のワークスペース（マルチモニタでフォーカス外の面も控えめに強調する）
 VISIBLE=" $(aerospace list-workspaces --monitor all --visible | tr '\n' ' ') "
 WINDOWS="$(aerospace list-windows --all --format '%{workspace}|%{app-name}')"
+# ワークスペースが乗っているモニタ。NSScreen の番号は sketchybar の display 番号と
+# 一致するのでそのまま使える（aerospace の monitor-id とは並び順が異なる）。
+DISPLAYS="$(aerospace list-workspaces --all --format '%{workspace}|%{monitor-appkit-nsscreen-screens-id}')"
 
 args=()
 
@@ -73,6 +76,13 @@ for sid in "$@"; do
     label.padding_left="$label_padding_left"
     label.padding_right="$label_padding_right"
   )
+
+  # そのワークスペースが属するモニタのバーにだけ出す。
+  # 割り当てが読めなかった場合は今の設定を触らない。
+  display="$(printf '%s\n' "$DISPLAYS" | awk -F'|' -v ws="$sid" '$1 == ws { print $2; exit }')"
+  if [ -n "$display" ]; then
+    args+=(display="$display")
+  fi
 done
 
 sketchybar "${args[@]}"

--- a/nix/services/darwin/sketchybar/plugins/volume.sh
+++ b/nix/services/darwin/sketchybar/plugins/volume.sh
@@ -1,17 +1,67 @@
-# volume_change のときはイベントが渡す $INFO を使い、それ以外（起動直後の
-# 強制更新など）は現在の出力音量を問い合わせる。
-# 従来は volume_change 以外で何も描画せず、起動直後に空のアイテムが残っていた。
+# 出力デバイスによっては AppleScript が音量を返さない（Bluetooth ヘッドセットなど。
+# `get volume settings` の output volume が missing value になる）。
+# sketchybar の volume_change は CoreAudio 由来なのでその場合でも値が届くため、
+# 受け取った値をここに控えておき、スクロール時の基準として使う。
+VOLUME_STATE="${TMPDIR:-/tmp}/sketchybar-volume"
+
+read_volume() {
+  local value
+  value="$(osascript -e 'output volume of (get volume settings)' 2>/dev/null)"
+  case "$value" in
+  '' | *[!0-9]*)
+    value="$(cat "$VOLUME_STATE" 2>/dev/null)"
+    ;;
+  esac
+  case "$value" in
+  '' | *[!0-9]*) return 1 ;;
+  esac
+  printf '%s' "$value"
+}
+
+# バーの外にカーソルが出たら popup を閉じる
+if [ "$SENDER" = "mouse.exited.global" ]; then
+  sketchybar --set "$NAME" popup.drawing=off
+  exit 0
+fi
+
+# バー上のスクロールで音量を上下する。
+# 音量を変えると volume_change が飛んでくるので、描画はそちらに任せる。
+if [ "$SENDER" = "mouse.scrolled" ]; then
+  DIRECTION="$(awk -v d="$SCROLL_DELTA" 'BEGIN { print (d > 0 ? 1 : (d < 0 ? -1 : 0)) }')"
+  if [ "$DIRECTION" != "0" ] && CURRENT="$(read_volume)"; then
+    NEXT=$((CURRENT + DIRECTION * 5))
+    if [ "$NEXT" -lt 0 ]; then
+      NEXT=0
+    elif [ "$NEXT" -gt 100 ]; then
+      NEXT=100
+    fi
+    osascript -e "set volume output volume $NEXT" 2>/dev/null
+  fi
+  exit 0
+fi
+
 if [ "$SENDER" = "volume_change" ]; then
   VOLUME="$INFO"
+  case "$VOLUME" in
+  '' | *[!0-9]*) ;;
+  *) printf '%s' "$VOLUME" >"$VOLUME_STATE" ;;
+  esac
 else
-  VOLUME="$(osascript -e 'output volume of (get volume settings)' 2>/dev/null)"
+  VOLUME="$(read_volume)" || VOLUME=""
   MUTED="$(osascript -e 'output muted of (get volume settings)' 2>/dev/null)"
   if [ "$MUTED" = "true" ]; then
     VOLUME=0
   fi
 fi
 
-if [ -z "$VOLUME" ] || [ "$VOLUME" = "missing value" ]; then
+# 値が取れないときは数字を出さない（古い値が残り続けるのを避ける）
+if [ -z "$VOLUME" ]; then
+  sketchybar --set "$NAME" \
+    icon="󰕾" \
+    icon.color="$COLOR_MUTED" \
+    label.drawing=off \
+    background.color="$COLOR_BG" \
+    background.drawing=on
   exit 0
 fi
 
@@ -31,7 +81,9 @@ esac
 sketchybar --set "$NAME" \
   icon="$ICON" \
   icon.color="$COLOR_PINK" \
+  label="$VOLUME%" \
+  label.color="$COLOR_PINK" \
+  label.drawing=on \
   background.color="$COLOR_BG" \
   background.drawing=on \
-  label="$VOLUME%" \
-  label.color="$COLOR_PINK"
+  --set volume.popup.slider slider.percentage="$VOLUME"

--- a/nix/services/darwin/sketchybar/plugins/volume_click.sh
+++ b/nix/services/darwin/sketchybar/plugins/volume_click.sh
@@ -1,0 +1,66 @@
+# 出力デバイス一覧を popup に流し込んでから開閉する。
+#
+# デバイス数は接続状況で変わるのに popup のアイテムは事前に作っておく必要があるため、
+# スロットを固定数用意して使う分だけ描画する。スロットを超えた分は表示できないので、
+# 溢れたときは最後のスロットにその旨を出す。
+DEVICE_PLUGIN="$1"
+SLOTS=16
+
+CURRENT="$(SwitchAudioSource -c -t output 2>/dev/null)"
+
+args=()
+i=0
+overflow=0
+
+while IFS= read -r device; do
+  [ -n "$device" ] || continue
+
+  if [ "$i" -ge "$SLOTS" ]; then
+    overflow=$((overflow + 1))
+    continue
+  fi
+
+  if [ "$device" = "$CURRENT" ]; then
+    icon="󰄬"
+    icon_color="$COLOR_PINK"
+    label_color="$COLOR_WHITE"
+  else
+    icon="󰕾"
+    icon_color="$COLOR_MUTED"
+    label_color="$COLOR_MUTED"
+  fi
+
+  # デバイス名に空白や記号が含まれても壊れないように click_script 用に引用する
+  printf -v quoted '%q' "$device"
+
+  args+=(
+    --set "volume.popup.device.$i"
+    drawing=on
+    icon="$icon"
+    icon.color="$icon_color"
+    label="$device"
+    label.color="$label_color"
+    click_script="$DEVICE_PLUGIN $quoted"
+  )
+  i=$((i + 1))
+done < <(SwitchAudioSource -a -t output 2>/dev/null)
+
+if [ "$overflow" -gt 0 ] && [ "$SLOTS" -gt 0 ]; then
+  last=$((SLOTS - 1))
+  args+=(
+    --set "volume.popup.device.$last"
+    drawing=on
+    icon="󰕾"
+    icon.color="$COLOR_MUTED"
+    label="... and $overflow more"
+    label.color="$COLOR_MUTED"
+    click_script=""
+  )
+fi
+
+while [ "$i" -lt "$SLOTS" ]; do
+  args+=(--set "volume.popup.device.$i" drawing=off)
+  i=$((i + 1))
+done
+
+sketchybar "${args[@]}" --set "$NAME" popup.drawing=toggle

--- a/nix/services/darwin/sketchybar/plugins/volume_device.sh
+++ b/nix/services/darwin/sketchybar/plugins/volume_device.sh
@@ -1,0 +1,10 @@
+# popup で選ばれた出力デバイスに切り替える。
+#
+# デバイスごとに音量が別管理なので、切り替え後に volume_update を投げて
+# バーの表示とスライダーを現在値に合わせ直す。
+[ -n "$1" ] || exit 0
+
+SwitchAudioSource -s "$1" -t output >/dev/null 2>&1
+
+sketchybar --set volume popup.drawing=off
+sketchybar --trigger volume_update

--- a/nix/services/darwin/sketchybar/plugins/volume_slider.sh
+++ b/nix/services/darwin/sketchybar/plugins/volume_slider.sh
@@ -1,0 +1,8 @@
+# popup のスライダーをドラッグ/クリックした位置から音量を設定する。
+# $PERCENTAGE はスライダー上の位置を 0-100 で sketchybar が渡してくる。
+# 設定すると volume_change が飛ぶので、描画は volume.sh に任せる。
+case "$PERCENTAGE" in
+'' | *[!0-9]*) exit 0 ;;
+esac
+
+osascript -e "set volume output volume $PERCENTAGE" 2>/dev/null

--- a/nix/services/darwin/workspaces.nix
+++ b/nix/services/darwin/workspaces.nix
@@ -1,0 +1,21 @@
+# AeroSpace のワークスペース一覧。
+#
+# AeroSpace の persistent-workspaces と Sketchybar のアイテム生成で共有する。
+# Sketchybar はアイテムを起動時に作るため、実行時に `aerospace list-workspaces --all`
+# を引くと「そのときウィンドウがあるワークスペース」しか拾えず、後から使い始めた
+# 番号のアイテムが存在しないままになる。両者をこのリストから生成することで、
+# ウィンドウの有無に関わらず同じ集合を見るようにしている。
+#
+# AeroSpace は home-manager、Sketchybar は nix-darwin と別のモジュール系にいるため、
+# オプション経由ではなく素のデータとして import している。
+[
+  "1"
+  "2"
+  "3"
+  "4"
+  "5"
+  "6"
+  "7"
+  "8"
+  "9"
+]


### PR DESCRIPTION
## Summary

Follow-up to #107. Continues in the recommended order from that work.

## Workspaces per display

Each bar now shows only the workspaces that belong to its own monitor. Before this every bar carried all nine, including the ones that can never appear there.

The mapping is not the obvious one: AeroSpace's `monitor-id` is ordered left to right, while sketchybar's `display` index follows NSScreen. Measured on this machine:

| AeroSpace `monitor-id` | name | `monitor-appkit-nsscreen-screens-id` | sketchybar display |
| --- | --- | --- | --- |
| 1 | LCD-GC243HXD | 2 | 2 |
| 2 | Built-in Retina Display | 1 | 1 |
| 3 | LCD-GC271X | 3 | 3 |

So `monitor-appkit-nsscreen-screens-id` is what the item's `display` is set from.

## Shared workspace list

Items are created when sketchybar starts, so asking `aerospace list-workspaces --all` at that moment only finds the workspaces that happen to hold a window; a number used later never gets an item. The list now lives in `nix/services/darwin/workspaces.nix` and feeds both AeroSpace's `persistent-workspaces` and the sketchybar item generation. AeroSpace runs under home-manager and sketchybar under nix-darwin, so it is imported as plain data rather than through a module option.

## No more periodic refresh

The workspace driver had `update_freq=15` as a safety net. AeroSpace now emits the refresh event from `on-focus-changed` and `on-focused-monitor-changed`, which covers windows opening and closing, so the polling is gone.

## Volume

- Scroll over the item to change the volume
- Popup with a slider and the list of output devices, switching via `switchaudio-osx`
- Some output devices do not answer the AppleScript volume query — the current `INZONE Buds - Chat` returns `missing value` for `output volume`. The value that arrives with `volume_change` (which sketchybar reads from CoreAudio) is kept and reused, and no stale number is drawn when nothing is known

## Media

Right click opens a popup with previous / play / next, so a left click still toggles playback as before. The play icon follows the actual player state.

## New items

- **Input source** — driven by the system-wide `AppleSelectedInputSourcesChangedNotification`, so no polling. Verified switching EN ↔ JA
- **CPU** — a graph fed from `ps`. `top -l 1` was measured at 1.3s per sample and is too slow for this
- **Memory** — from `memory_pressure`, measured at 9ms
- **GitHub notifications** — count from `gh api notifications`, hidden when there is none

Tailscale was on the list but is not set up on this host (`nix/services/tailscale.nix` is not imported by any profile and the CLI is not installed), so no item was added for it.

## Test plan

- `nix build .#darwinConfigurations.siraken-mbp.system` passes
- Applied with `darwin-rebuild switch` and verified on the running bar:
  - workspaces appear only on their own display, checked on all three
  - volume popup shows the slider and 13 output devices with the current one marked
  - media popup shows the three controls and tracks the paused state
  - input source updates on the event, EN ↔ JA
  - CPU, memory and GitHub items all render with live values
- Every plugin smoke-tested against a mocked `sketchybar` before applying

🤖 Generated with [Claude Code](https://claude.com/claude-code)
