### PR TITLE
style(sketchybar): balance the gaps above and below the bar

### DIFF
--- a/nix/services/darwin/aerospace.nix
+++ b/nix/services/darwin/aerospace.nix
@@ -136,9 +136,13 @@ in
         inner.vertical = 6;
         outer.left = 10;
         outer.bottom = 10;
+        # Sketchybar の島は画面上端から 36px までに収まる（y_offset 2 + バー内の余白 4
+        # + 島の高さ 30）。ウィンドウ上端を 42 にすることで島との間に 6px 空く。
+        # 内蔵ディスプレイはノッチのぶん 32 が最初から使用不可なので差分の 10 でよい
+        # （NSScreen の visibleFrame を実測して確認: 内蔵 topReserved=32 / 外部 0）。
         outer.top = [
           { monitor.main = 10; }
-          42 # 32 (external bar) + 10 (top_padding)
+          42
         ];
         outer.right = 10;
       };

--- a/nix/services/darwin/sketchybar/default.nix
+++ b/nix/services/darwin/sketchybar/default.nix
@@ -83,9 +83,14 @@ in
   services.sketchybar = {
     enable = true;
     config = ''
+      # バー自体は透明で、島だけが浮いて見える構成。
+      # 島は 30px の背景が 38px のバーの中央に置かれるので、バー内で上下に 4px ずつ
+      # 余白がある。y_offset=2 を足すと画面上端から島まで 6px、島の下端 (36) から
+      # ウィンドウ上端 (42, AeroSpace の outer.top) までも 6px となり上下が揃う。
       sketchybar --bar \
         position=top \
         height=38 \
+        y_offset=2 \
         blur_radius=0 \
         font_smoothing=on \
         color=${colors.transparent}


### PR DESCRIPTION
## Summary

The bar looked top-heavy: 4px above the island and 8px below it.

The 30px island sits centred in the 38px bar, so there is 4px inside the bar on each side of it, and AeroSpace starts windows at 42. A `y_offset` of 2 puts the island at 6–36, which makes both gaps 6px.

```
画面上端
│  6px          ← y_offset 2 + バー内の余白 4
┌────────────┐
│  島 30px    │
└────────────┘
│  6px          ← ウィンドウ上端 42 − 島の下端 36
══════════════ ウィンドウ
```

This needs no change to the AeroSpace gaps, so the window area stays exactly as it was.

## Note on the AeroSpace comment

The comment described the 42 as `32 (external bar) + 10 (top_padding)`, but the bar is 38 tall, not 32. Measured from `NSScreen` `visibleFrame`:

| display | reserved at top |
| --- | --- |
| Built-in Retina | 32 (notch) |
| LCD-GC243HXD | 0 |
| LCD-GC271X | 0 |

The comment now records that. The values are unchanged.

## Test plan

- `nix build .#darwinConfigurations.siraken-mbp.system` passes
- Applied with `darwin-rebuild switch`; the island measures y=6..36, giving 6px above and 6px below

🤖 Generated with [Claude Code](https://claude.com/claude-code)
