### PR TITLE
feat(nix): push locally-built paths to our own Cachix

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -158,11 +158,33 @@ JDK は `gradle`/`maven`/`sbt`/`scala` 経由の zulu21 + homebrew `openjdk@21`�
 
 あわせて `nix.optimise.automatic = true`（現状 `auto-optimise-store = false`）でストア重複排除、gc の `--delete-older-than 7d` の見直しも。
 
-### 8. 自前バイナリキャッシュが無い（「ビルドせずキャッシュ」の本命）
+### 8. 自前バイナリキャッシュが無い（「ビルドせずキャッシュ」の本命）— 対応済み
 
 上流に無い派生（fish補完、nixvim ラッパー、override 済みパッケージ、sketchybar スクリプト等）は必ずローカルビルドになる。**public リポジトリなので Cachix 無料枠 / FlakeHub Cache が使える**。macOS runner で `.#darwinConfigurations.siraken-mbp.system` をビルドして push すれば、手元の `darwin-rebuild switch` はダウンロードのみになる（closure 全体ではなく「上流に無いパスだけ」を push すれば容量は小さく収まる）。
 
 補足: eval 自体は暖機後 **約8秒**（pure/impure ともほぼ同じ）でボトルネックではない。効くのは上記のビルド側。なお `cache.numtide.com` の鍵 `niks3.numtide.com-1:…` は narinfo の Sig と一致しており**正しい**ことを確認済み。
+
+**対応**（2026-08-03）:
+
+まず実測した。`siraken-mbp` の system closure の全 1174 パスについて、設定済み substituter 全てに narinfo を問い合わせた結果:
+
+| | パス数 |
+| --- | --- |
+| closure 全体 | 1174（12.6 GiB） |
+| `cache.nixos.org` に無い | 295 |
+| うち `nix-community.cachix.org` にあった | 71 |
+| うち `cache.numtide.com` にあった | 10 |
+| **どこにも無い＝毎回ローカルビルド** | **214（286 MiB）** |
+
+内訳は `mise` 105 MiB・`1password-cli` 77 MiB・emacs パッケージ 77 パス 99 MiB・home-manager 生成物 35 パス・sketchybar 等のスクリプト 22 パス。`mise` は override を除去済み（P1-4）でも素の nixpkgs のまま `cache.nixos.org` が 404 で、上流が aarch64-darwin をビルドしていないだけだった。`1password-cli` は unfree なので Hydra が元々ビルドしない。つまりこの 182 MiB は自前キャッシュ以外に回避手段が無い。
+
+- `siraken-dotfiles.cachix.org`（public）を substituters と trusted-public-keys に追加
+- push は `nix-cache-push` スクリプトで行う。closure を丸ごと渡すと 12.6 GiB になり無料枠を使い切るため、上流の substituter に narinfo を並列問い合わせして**どこにも無いパスだけ**に絞る。実測 214 パス / 13 秒
+- 認証は 1Password Shell Plugin に載せた。ただしあれはシェル関数なのでスクリプトからは効かず、`op plugin run -- cachix push` 経由で呼んでいる
+- `post-build-hook` は採らなかった。nix daemon（root）側にトークンを置く必要があり、宣言的管理と相性が悪い
+- 新規スクリプトなので `writeShellApplication` + `runtimeInputs` で書いた（P2-15 の方針を新規分から適用）
+
+**CI からの push は見送り**: CI は `ubuntu-latest` なので aarch64-darwin をビルドできない。macOS runner 案はディスク 14 GB に対し closure 12.6 GiB で成立しない（P0-2 の結論を今回の実測が裏付けた）。当面は手元の Mac から push する運用とし、`siraken-macmini` 側がその恩恵を受ける。
 
 ### 9. flake input の重複と未使用 input
 

--- a/nix/modules/nix-caches.nix
+++ b/nix/modules/nix-caches.nix
@@ -7,12 +7,16 @@
       "https://nix-community.cachix.org"
       "https://devenv.cachix.org"
       "https://cache.numtide.com"
+      # 上流がビルドしていないもの (mise、unfree な 1password-cli、emacs パッケージ、
+      # このリポジトリ由来の派生) を置く自前のキャッシュ。`nix-cache-push` で更新する。
+      "https://siraken-dotfiles.cachix.org"
     ];
     trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
       "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
+      "siraken-dotfiles.cachix.org-1:UJ/LRyGgN5R3AagxTnKTFbbprNu2G3Ylg6LYTgPmc/w="
     ];
     always-allow-substitutes = true;
   };

--- a/nix/programs/scripts/default.nix
+++ b/nix/programs/scripts/default.nix
@@ -11,5 +11,76 @@
     (pkgs.writeShellScriptBin "gd-select" ''
       ghq list -p | fzf
     '')
+
+    (pkgs.writeShellApplication {
+      name = "nix-cache-push";
+      runtimeInputs = with pkgs; [
+        cachix
+        coreutils
+        curl
+        findutils
+        gawk
+        gnugrep
+        gnused
+        nix
+      ];
+      text = ''
+        # システムの closure のうち、上流のバイナリキャッシュがどれも持っていない
+        # パスだけを自前の Cachix へ push する。
+        #
+        # closure 全体は 1174 パス / 12.6 GiB あるが、上流に無いのは 214 パス /
+        # 286 MiB だけだった (2026-08-03 実測。mise 105MiB・1password-cli 77MiB・
+        # emacs パッケージ 99MiB・このリポジトリ由来の派生など)。丸ごと push すると
+        # 無料枠を使い切ってしまうため、narinfo の有無で絞り込んでいる。
+        #
+        # cachix の認証情報は 1Password Shell Plugin が持っているが、あれはシェル関数
+        # なのでスクリプトからは効かない。op があれば op plugin run 経由で呼ぶ。
+
+        CACHE="''${CACHIX_CACHE:-siraken-dotfiles}"
+        TARGET="''${1:-/run/current-system}"
+
+        tmp="$(mktemp -d)"
+        trap 'rm -rf "$tmp"' EXIT
+
+        nix-store --query --requisites "$TARGET" | sort -u > "$tmp/closure"
+        awk -F/ '{ print substr($NF, 1, 32) }' "$tmp/closure" | sort -u > "$tmp/todo"
+        printf 'closure: %s パス\n' "$(wc -l < "$tmp/closure" | tr -d ' ')"
+
+        nix config show substituters | tr ' ' '\n' | sed '/^$/d; s:/*$::' | sort -u > "$tmp/hosts"
+
+        while read -r host; do
+          # 自分のキャッシュに問い合わせても意味がない
+          case "$host" in
+          *"$CACHE".cachix.org) continue ;;
+          esac
+          [ -s "$tmp/todo" ] || break
+
+          # curl の -o は URL ごとの指定なので、設定ファイル側に書く必要がある
+          awk -v h="$host" '{ printf "url = \"%s/%s.narinfo\"\noutput = \"/dev/null\"\n", h, $0 }' \
+            "$tmp/todo" > "$tmp/urls.conf"
+          curl -s --parallel --parallel-max 32 -I \
+            -w '%{http_code} %{url_effective}\n' --config "$tmp/urls.conf" > "$tmp/res" || true
+          awk '$1 != "200" { n = split($2, a, "/"); h = a[n]; sub(/\.narinfo$/, "", h); print h }' \
+            "$tmp/res" > "$tmp/next"
+          mv "$tmp/next" "$tmp/todo"
+
+          printf '  %s を除いて残り %s パス\n' "$host" "$(wc -l < "$tmp/todo" | tr -d ' ')"
+        done < "$tmp/hosts"
+
+        if [ ! -s "$tmp/todo" ]; then
+          echo '上流に無いパスはありませんでした'
+          exit 0
+        fi
+
+        grep -F -f "$tmp/todo" "$tmp/closure" > "$tmp/push"
+        printf '%s パスを %s へ push します\n' "$(wc -l < "$tmp/push" | tr -d ' ')" "$CACHE"
+
+        if command -v op > /dev/null 2>&1; then
+          xargs op plugin run -- cachix push "$CACHE" < "$tmp/push"
+        else
+          xargs cachix push "$CACHE" < "$tmp/push"
+        fi
+      '';
+    })
   ];
 }


### PR DESCRIPTION
## Summary

Addresses P1-8 of `IMPROVEMENTS.md`. Measured before building anything.

## What is actually rebuilt every time

Every one of the 1174 paths in the `siraken-mbp` system closure was queried against all configured substituters:

| | paths |
| --- | --- |
| closure | 1174 (12.6 GiB) |
| missing from `cache.nixos.org` | 295 |
| of those, in `nix-community.cachix.org` | 71 |
| of those, in `cache.numtide.com` | 10 |
| **in none of them → rebuilt locally** | **214 (286 MiB)** |

| | paths | size |
| --- | --- | --- |
| `mise` | 1 | 105 MiB |
| `1password-cli` | 1 | 77 MiB |
| emacs packages | 77 | 99 MiB |
| home-manager generated | 35 | 0.6 MiB |
| sketchybar plugins etc. | 22 | ~0 |
| other | 78 | 4 MiB |

`mise` carries no `overrideAttrs` any more (removed in P1-4), yet plain nixpkgs `mise` still 404s on `cache.nixos.org` for aarch64-darwin — upstream simply does not build it. `1password-cli` is unfree, so Hydra never will. Those 182 MiB cannot be avoided any other way.

## What this adds

- `siraken-dotfiles.cachix.org` (public) in `substituters` and `trusted-public-keys`
- `nix-cache-push`, which fills it

Handing the whole closure to `cachix push` would upload 12.6 GiB and exhaust the free tier immediately. The script asks every upstream substituter for each `narinfo` in parallel and keeps only the paths none of them has. Measured: 1174 → 214 paths in 13 seconds.

```
closure: 1174 パス
  https://cache.nixos.org を除いて残り 295 パス
  https://cache.numtide.com を除いて残り 285 パス
  https://devenv.cachix.org を除いて残り 285 パス
  https://nix-community.cachix.org を除いて残り 214 パス
214 パスを siraken-dotfiles へ push します
```

Authentication rides on the existing 1Password shell plugin, which already lists `cachix`. That plugin is a shell function and does not reach a script, so the push goes through `op plugin run`. A `post-build-hook` was not used: it would need the token in root's environment, outside anything the repository can manage.

The script is written with `writeShellApplication` and `runtimeInputs`, following P2-15, which the two existing `writeShellScriptBin` helpers still do not.

## Why CI does not do this

CI runs on `ubuntu-latest` and cannot build aarch64-darwin. A macOS runner has 14 GB of disk against a 12.6 GiB closure, which is what P0-2 already concluded; the measurement here confirms the closure size. Pushing happens from the Mac, and `siraken-macmini` is what benefits.

## Test plan

- `nix build .#darwinConfigurations.siraken-mbp.system` passes, including the `shellcheck` run that `writeShellApplication` performs
- The script was run with the push replaced by an echo: it walks the four upstream substituters and lands on exactly the 214 paths found by the manual measurement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
