### PR TITLE
fix(nix): let nix-cache-push skip what our cache already holds

### DIFF
--- a/nix/programs/scripts/default.nix
+++ b/nix/programs/scripts/default.nix
@@ -48,11 +48,9 @@
 
         nix config show substituters | tr ' ' '\n' | sed '/^$/d; s:/*$::' | sort -u > "$tmp/hosts"
 
+        # 自前のキャッシュも問い合わせ対象に含める。既に載っているパスが落ちるので、
+        # 2 回目以降は差分だけが push 対象になる。
         while read -r host; do
-          # 自分のキャッシュに問い合わせても意味がない
-          case "$host" in
-          *"$CACHE".cachix.org) continue ;;
-          esac
           [ -s "$tmp/todo" ] || break
 
           # curl の -o は URL ごとの指定なので、設定ファイル側に書く必要がある
@@ -68,7 +66,7 @@
         done < "$tmp/hosts"
 
         if [ ! -s "$tmp/todo" ]; then
-          echo '上流に無いパスはありませんでした'
+          echo 'どのキャッシュにも無いパスはありませんでした'
           exit 0
         fi
 


### PR DESCRIPTION
## Summary

Fixes a mistake in #111. The script left our own cache out of the availability check:

```sh
# 自分のキャッシュに問い合わせても意味がない
case "$host" in
*"$CACHE".cachix.org) continue ;;
esac
```

The reasoning was wrong. Including it is exactly what makes a second run push only the delta. Without it, every run reported the same 212 paths, and only Cachix's own duplicate check stopped the upload from actually repeating.

## Verified after the first real push

```
closure: 1172 パス
  https://cache.nixos.org を除いて残り 293 パス
  https://cache.numtide.com を除いて残り 283 パス
  https://devenv.cachix.org を除いて残り 283 パス
  https://nix-community.cachix.org を除いて残り 212 パス
  https://siraken-dotfiles.cachix.org を除いて残り 0 パス
どのキャッシュにも無いパスはありませんでした
```

Independently confirmed that all 212 paths the upstreams lack are now in `siraken-dotfiles.cachix.org`.

If a path is later dropped from our cache, the same check picks it up again and it gets re-pushed.

## Test plan

- `nix build .#darwinConfigurations.siraken-mbp.system` passes
- Script run with the push replaced by an echo; output above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
