### PR TITLE
style(sketchybar): drop the workspace app icons onto the digit's centre

### DIFF
--- a/nix/services/darwin/sketchybar/default.nix
+++ b/nix/services/darwin/sketchybar/default.nix
@@ -146,6 +146,9 @@ in
       # AeroSpace workspaces
       sketchybar --add event aerospace_workspace_change
 
+      # label には sketchybar-app-font のアプリアイコンが入る。このフォントの
+      # グリフは icon 側の Hack より 1pt ほど高い位置に乗り、画素で測ると数字の
+      # 中心より 1.5px (retina) 上にずれるので y_offset で下げている。
       SPACE_SIDS=()
       SPACE_IDS=()
       for sid in ${lib.concatStringsSep " " workspaces}; do
@@ -163,6 +166,7 @@ in
             label.font="sketchybar-app-font:Regular:14.0" \
             label.color=${colors.muted} \
             label.drawing=off \
+            label.y_offset=-1 \
             padding_left=2 \
             padding_right=2 \
             click_script="${aerospace} workspace $sid"


### PR DESCRIPTION
## Summary

The app icons in the workspace items sat visibly above the workspace number. `sketchybar-app-font` places its glyphs higher than Hack does, so mixing the two in one item left them misaligned.

## Measured

Decoded the screenshots and compared the vertical ink extents of the digit against the icon, in retina pixels (2x):

| `label.y_offset` | digit centre | icon centre | offset |
| --- | --- | --- | --- |
| 0 (before) | 38.5 | 37.0 | **−1.5** (icon high) |
| **−1** | 38.5 | 39.0 | **+0.5** |
| −2 | 38.5 | 41.0 | +2.5 |

`y_offset` is in points, so each step moves two retina pixels; −1 is the closest an integer value gets. The digit itself is already centred in the island (centre 21.25pt against the island's 21pt), so only the label needed moving.

## Test plan

- `nix build .#darwinConfigurations.siraken-mbp.system` passes
- Offsets 0, −1 and −2 applied to the running bar and captured, with the numbers above coming from those images

🤖 Generated with [Claude Code](https://claude.com/claude-code)
