### PR TITLE
style(sketchybar): even out the padding around the workspace highlight

### DIFF
--- a/nix/services/darwin/sketchybar/default.nix
+++ b/nix/services/darwin/sketchybar/default.nix
@@ -149,6 +149,9 @@ in
       # label には sketchybar-app-font のアプリアイコンが入る。このフォントの
       # グリフは icon 側の Hack より 1pt ほど高い位置に乗り、画素で測ると数字の
       # 中心より 1.5px (retina) 上にずれるので y_offset で下げている。
+      #
+      # ハイライトの周囲の余白は上下が (30 - 22) / 2 - 1(枠線) = 3px。左右も揃える
+      # には padding からブラケットの枠線 1px を引いた値が 3 になればよいので 4 にする。
       SPACE_SIDS=()
       SPACE_IDS=()
       for sid in ${lib.concatStringsSep " " workspaces}; do
@@ -167,8 +170,8 @@ in
             label.color=${colors.muted} \
             label.drawing=off \
             label.y_offset=-1 \
-            padding_left=2 \
-            padding_right=2 \
+            padding_left=4 \
+            padding_right=4 \
             click_script="${aerospace} workspace $sid"
         SPACE_SIDS+=("space.$sid")
         SPACE_IDS+=("$sid")


### PR DESCRIPTION
## Summary

The purple highlight had 1px of island showing on its left and right but 3px above and below.

## Measured

Read the pixels along the centre lines of the highlighted workspace (the external display is 1x, so 1px = 1pt):

```
horizontal (y=21):  border[1532] bg[1533] highlight[1534..1626] bg[1627] border[1628]
                    → 1px each side

vertical (x=1580):  border[6] bg[7..9] highlight[10..31] bg[32..34] border[35]
                    → 3px each side
```

Each axis was symmetric on its own, but they did not agree. The text inside the pill was fine — 9px on both sides.

## Options measured

| | gaps | inter-item | pill height |
| --- | --- | --- | --- |
| current — `padding=2 / height=22` | 1 left-right, 3 top-bottom | 4px | 22 |
| **chosen — `padding=4 / height=22`** | **3 all round** | 8px | 22 |
| `padding=2 / height=26` | 1 all round | 4px | 26 |
| `padding=3 / height=24` | 2 all round | 6px | 24 |

The vertical figure is `(30 − 22) / 2` minus the 1px border, so the horizontal one matches once the item padding is 4. The pill keeps its 22px height, leaving the look above and below untouched. The only side effect is that two adjacent workspaces now sit 8px apart instead of 4px.

The bracket's own `background.padding_left/right` was tried first, since it would have widened the island without touching the gap between workspaces, but it had no effect on a bracket.

## Test plan

- `nix build .#darwinConfigurations.siraken-mbp.system` passes
- All four combinations applied to the running bar and measured from the captures; numbers above are from those runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
