### PR TITLE
feat(herdr): manage config.toml via home-manager

### DIFF
--- a/nix/hosts/siraken-mbp/home.nix
+++ b/nix/hosts/siraken-mbp/home.nix
@@ -6,6 +6,7 @@
     # host-specific programs
     ../../programs/fastfetch
     ../../programs/fish
+    ../../programs/herdr
     # ../../programs/spotify-player # disabled: nixpkgs linker crash (cctools-binutils-darwin)
     # ../../programs/vscode
   ];

--- a/nix/programs/herdr/default.nix
+++ b/nix/programs/herdr/default.nix
@@ -1,0 +1,86 @@
+# herdr 本体は Homebrew 管理 (nix/hosts/siraken-mbp/default.nix の `brews`)。
+# `package = null` で nixpkgs 版の導入だけを止め、home-manager には
+# `$XDG_CONFIG_HOME/herdr/config.toml` の生成を任せる。設定が変わると
+# activation で `herdr server reload-config` が走る (home-manager 側の onChange)。
+#
+# 設定キーの一覧: https://herdr.dev/docs/config-reference/
+# 手元のデフォルト値: `herdr --default-config`
+{ pkgs, ... }:
+{
+  programs.herdr = {
+    enable = true;
+    package = null;
+
+    settings = {
+      onboarding = false;
+
+      theme = {
+        # tmux (tokyo-night-tmux) / zellij / helix と揃えて TokyoNight。
+        name = "tokyo-night";
+        auto_switch = false;
+      };
+
+      terminal = {
+        # tmux (`programs.tmux.shell`) と zellij (`default_shell`) に合わせて bash。
+        # atuin / starship / zoxide の bash 統合は profile-core で有効なので、
+        # ログインシェル (zsh) と操作感は変わらない。
+        default_shell = "${pkgs.bash}/bin/bash";
+        new_cwd = "follow";
+      };
+
+      update = {
+        # 更新は brew 側で行うので herdr 自身のバージョンチェックは止める。
+        # エージェント検出マニフェストの更新だけは残す。
+        version_check = false;
+        manifest_check = true;
+      };
+
+      keys = {
+        # herdr のデフォルトのまま。tmux の prefix (`programs.tmux.shortcut = "b"`)
+        # と同じキーなので、herdr の中で tmux を動かすと内側までイベントが届かない。
+        # nixvim の blink.cmp `<C-b>` (ドキュメント上スクロール) も同様。
+        # 入れ子で使うようになったら別のキーに変える。
+        prefix = "ctrl+b";
+
+        command = [
+          {
+            # programs.gitui をポップアップで開く。alt+ を含む組み合わせは Ghostty の
+            # macos-option-as-alt が未設定 = レイアウトが ABC のため false 相当で、
+            # Option が Alt として送られない。prefix + 単独キーにしておく。
+            key = "prefix+u";
+            type = "popup";
+            command = "gitui";
+            width = "80%";
+            height = "80%";
+          }
+        ];
+      };
+
+      ui = {
+        # エージェントの状態順に並べる (待ち行列)。space ごとに並べたいなら "spaces"。
+        agent_panel_sort = "priority";
+
+        # `ui.mouse_capture` は既定 (true) のまま。tmux / zellij ではマウスを切って
+        # いるが、herdr はサイドバー自体がマウス UI で、init.el の xterm-mouse-mode
+        # や gitui / bottom もマウスを使うため、ここだけ流儀を合わせない。
+
+        # 既存の config.toml を踏襲して macOS の通知センターへ出す。
+        toast.delivery = "system";
+      };
+
+      experimental = {
+        # 日本語入力対策 (macOS 限定・best-effort)。prefix 中だけ ASCII 入力へ
+        # 切り替え、自前でカーソルを描く TUI エージェントでも変換候補が追従するようにする。
+        # 副作用 (vim のノーマルモードで余分なカーソルが出る) を避けるため、
+        # 対象は coding-agents で使っているエージェントのみに絞る。
+        switch_ascii_input_source_in_prefix = true;
+        reveal_hidden_cursor_for_cjk_ime = true;
+        cjk_ime_agents = [
+          "claude"
+          "codex"
+          "opencode"
+        ];
+      };
+    };
+  };
+}

--- a/nix/programs/herdr/default.nix
+++ b/nix/programs/herdr/default.nix
@@ -1,11 +1,11 @@
 # herdr 本体は Homebrew 管理 (nix/hosts/siraken-mbp/default.nix の `brews`)。
 # `package = null` で nixpkgs 版の導入だけを止め、home-manager には
 # `$XDG_CONFIG_HOME/herdr/config.toml` の生成を任せる。設定が変わると
-# activation で `herdr server reload-config` が走る (home-manager 側の onChange)。
+# activation で `herdr server reload-config` が走る (下の onChange)。
 #
 # 設定キーの一覧: https://herdr.dev/docs/config-reference/
 # 手元のデフォルト値: `herdr --default-config`
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
   programs.herdr = {
     enable = true;
@@ -83,4 +83,12 @@
       };
     };
   };
+
+  # home-manager の onChange は `package = null` のとき裸の `herdr` を呼ぶ。activation は
+  # `launchctl asuser … sudo -u siraken --set-home` 経由で PATH に /opt/homebrew/bin を
+  # 含まないため `command not found` になり、`|| true` に飲まれて reload が黙って飛ぶ。
+  # brew の絶対パス指定に差し替える (variable.nix の JAVA_HOME と同じ macOS 前提)。
+  xdg.configFile."herdr/config.toml".onChange = lib.mkForce ''
+    /opt/homebrew/bin/herdr server reload-config || true
+  '';
 }

--- a/nix/programs/herdr/default.nix
+++ b/nix/programs/herdr/default.nix
@@ -1,15 +1,19 @@
-# herdr 本体は Homebrew 管理 (nix/hosts/siraken-mbp/default.nix の `brews`)。
-# `package = null` で nixpkgs 版の導入だけを止め、home-manager には
-# `$XDG_CONFIG_HOME/herdr/config.toml` の生成を任せる。設定が変わると
-# activation で `herdr server reload-config` が走る (下の onChange)。
+# macOS では herdr 本体を Homebrew で入れている (nix/hosts/siraken-mbp/default.nix の
+# `brews`) ので `package = null` で nixpkgs 版の導入だけを止め、home-manager には
+# `$XDG_CONFIG_HOME/herdr/config.toml` の生成を任せる。それ以外 (WSL など) は
+# nixpkgs の herdr をそのまま使うため、両方とも既定のままでよい。
 #
 # 設定キーの一覧: https://herdr.dev/docs/config-reference/
 # 手元のデフォルト値: `herdr --default-config`
 { pkgs, lib, ... }:
+let
+  # macOS だけ brew 管理。この分岐が `package` と onChange の両方を決める。
+  useBrew = pkgs.stdenv.isDarwin;
+in
 {
   programs.herdr = {
     enable = true;
-    package = null;
+    package = lib.mkIf useBrew null;
 
     settings = {
       onboarding = false;
@@ -29,7 +33,7 @@
       };
 
       update = {
-        # 更新は brew 側で行うので herdr 自身のバージョンチェックは止める。
+        # 更新は brew / nixpkgs 側で行うので herdr 自身のバージョンチェックは止める。
         # エージェント検出マニフェストの更新だけは残す。
         version_check = false;
         manifest_check = true;
@@ -64,12 +68,13 @@
         # いるが、herdr はサイドバー自体がマウス UI で、init.el の xterm-mouse-mode
         # や gitui / bottom もマウスを使うため、ここだけ流儀を合わせない。
 
-        # 既存の config.toml を踏襲して macOS の通知センターへ出す。
+        # 既存の config.toml を踏襲して OS の通知サービスへ出す (macOS なら通知センター)。
         toast.delivery = "system";
       };
 
       experimental = {
-        # 日本語入力対策 (macOS 限定・best-effort)。prefix 中だけ ASCII 入力へ
+        # 日本語入力対策。herdr 側の実装が macOS/Windows 限定なので Linux では
+        # no-op になるだけ。プラットフォームで分けずそのまま渡す。prefix 中だけ ASCII 入力へ
         # 切り替え、自前でカーソルを描く TUI エージェントでも変換候補が追従するようにする。
         # 副作用 (vim のノーマルモードで余分なカーソルが出る) を避けるため、
         # 対象は coding-agents で使っているエージェントのみに絞る。
@@ -88,7 +93,10 @@
   # `launchctl asuser … sudo -u siraken --set-home` 経由で PATH に /opt/homebrew/bin を
   # 含まないため `command not found` になり、`|| true` に飲まれて reload が黙って飛ぶ。
   # brew の絶対パス指定に差し替える (variable.nix の JAVA_HOME と同じ macOS 前提)。
-  xdg.configFile."herdr/config.toml".onChange = lib.mkForce ''
-    /opt/homebrew/bin/herdr server reload-config || true
-  '';
+  # nixpkgs 版を使う環境では `lib.getExe` が store の絶対パスを埋めるので上書き不要。
+  xdg.configFile."herdr/config.toml".onChange = lib.mkIf useBrew (
+    lib.mkForce ''
+      /opt/homebrew/bin/herdr server reload-config || true
+    ''
+  );
 }


### PR DESCRIPTION
## Summary

herdr is installed with Homebrew, so this only takes over the settings. The
home-manager module makes `package` nullable, and with `package = null` it
skips `home.packages` entirely and keeps just two things: the generated
`$XDG_CONFIG_HOME/herdr/config.toml` and its `onChange`, which calls
`herdr server reload-config` through the `herdr` on `PATH` — the brew one.

The module lives in `nix/programs/herdr/` but is imported from
`nix/hosts/siraken-mbp/home.nix` rather than a profile, because the brew
entry only exists on that host.

The four keys already in `~/.config/herdr/config.toml` (`onboarding`,
`theme.name`, `theme.auto_switch`, `ui.toast.delivery`) carry over unchanged;
a sorted diff of the generated file against the current one has no removals.
The rest follows what the repo already does elsewhere:

| setting | value | why |
| --- | --- | --- |
| `terminal.default_shell` | `pkgs.bash` | same as `programs.tmux.shell` and zellij's `default_shell`; the atuin/starship/zoxide bash integrations are on in `profile-core` |
| `keys.command` | gitui popup on `prefix+u` | `programs.gitui` is installed |
| `ui.agent_panel_sort` | `priority` | attention queue rather than grouping by space |
| `update.version_check` | `false` | updates go through brew; the agent-detection manifest check stays on |
| `experimental.*cjk_ime*` | on, scoped to claude/codex/opencode | Kotoeri is an enabled input source; the allow-list keeps the extra cursor out of non-agent panes |

## Keybinding conflicts checked

`keys.prefix` stays on herdr's default `ctrl+b`, which is also
`programs.tmux.shortcut = "b"` and nixvim's blink.cmp `<C-b>`. Deliberate —
running tmux inside herdr is what would break, and that isn't the workflow.
Two candidates were rejected while checking:

- `ctrl+g` collides with `keyboard-quit` in terminal Emacs. `programs.emacs`
  uses `emacs-nox` and `config/emacs/init.el` loads evil without calling
  `(evil-mode 1)`, so the stock Emacs bindings are live.
- `prefix+alt+g` for the gitui popup never fires. `macos-option-as-alt` is
  unset in `config/ghostty/config`, and Ghostty only defaults that to true on
  the U.S. Standard / U.S. International layouts — this machine is on `ABC`,
  so Option+g produces `©` instead of Alt. Hence the plain `prefix+u`.

AeroSpace was clear: every herdr default binding is prefix-scoped, and the one
direct binding (`remote_image_paste = ctrl+v`) is `--remote` only. Enabling
`focus_agent = "prefix+alt+1..9"` or `keys.indexed` would hit AeroSpace's
`alt-1..7`, so neither is set.

`ui.mouse_capture` is left at its default. tmux and zellij turn the mouse off,
but herdr's sidebar is a mouse UI, and `init.el` enables `xterm-mouse-mode`
while gitui and bottom want the mouse too.

## Test plan

- `herdr config check` on the generated TOML (in an isolated `XDG_CONFIG_HOME`)
  reports `config: ok`, with no unknown-key or invalid-keybinding warnings —
  confirmed to be path-aware by feeding it a deliberately broken file first
- `nix eval .#darwinConfigurations.siraken-mbp.system.drvPath` evaluates
- `nix fmt` clean

Not applied yet — `darwin-rebuild switch` still to run, which will move the
current `config.toml` aside as `config.toml.hm-backup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)