### PR TITLE
refactor: drop deprecated stdenv.isDarwin/isLinux

### DIFF
--- a/nix/modules/aliases.nix
+++ b/nix/modules/aliases.nix
@@ -61,7 +61,7 @@ let
     cx = "codex";
   };
 
-  darwinAliases = pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+  darwinAliases = pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
     # macOS specific
     ii = "open";
     mamp-htdocs = "cd /Applications/MAMP/htdocs";

--- a/nix/modules/home/profile-darwin.nix
+++ b/nix/modules/home/profile-darwin.nix
@@ -1,9 +1,10 @@
 # macOS-only additions on top of `profile-full.nix`.
 #
-# Kept as a separate module rather than a `lib.optionals pkgs.stdenv.isDarwin`
-# inside `profile-full.nix`: `imports` must not depend on module arguments that
-# are themselves derived from the configuration, so the platform split is made
-# explicit at the host level instead.
+# Kept as a separate module rather than a
+# `lib.optionals pkgs.stdenv.hostPlatform.isDarwin` inside `profile-full.nix`:
+# `imports` must not depend on module arguments that are themselves derived
+# from the configuration, so the platform split is made explicit at the host
+# level instead.
 { ... }:
 {
   imports = [

--- a/nix/modules/home/profile-full.nix
+++ b/nix/modules/home/profile-full.nix
@@ -25,7 +25,7 @@
   home = {
     sessionVariables = import ../variable.nix { inherit lib pkgs; };
 
-    packages = lib.optionals pkgs.stdenv.isLinux [
+    packages = lib.optionals pkgs.stdenv.hostPlatform.isLinux [
       pkgs.gcc
       pkgs.libgcc
       pkgs.xdg-utils

--- a/nix/modules/path.nix
+++ b/nix/modules/path.nix
@@ -1,7 +1,7 @@
 { lib, pkgs }:
 # homebrew の prefix と ~/Library 以下は macOS にしか無いので、
 # Linux (WSL/NixOS) の PATH には入れない。
-lib.optionals pkgs.stdenv.isDarwin [
+lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
   "/opt/homebrew/opt/openssl@3/bin" # Use openssl installed by homebrew
   "/opt/homebrew/sbin"
   "/opt/homebrew/bin"

--- a/nix/modules/variable.nix
+++ b/nix/modules/variable.nix
@@ -13,7 +13,7 @@
   COMPOSER_HOME = "$XDG_CONFIG_HOME/composer";
   BUN_INSTALL = "$HOME/.bun";
 }
-// lib.optionalAttrs pkgs.stdenv.isDarwin {
+// lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
   # 1Password の SSH エージェント。WSL では別の経路 (npiperelay) を使うため、
   # このソケットのパスは macOS でしか通用しない。
   SSH_AUTH_SOCK = "$HOME/.1password/agent.sock";

--- a/nix/programs/ghostty/default.nix
+++ b/nix/programs/ghostty/default.nix
@@ -1,6 +1,6 @@
 { pkgs, config, ... }:
 let
-  isDarwin = pkgs.stdenv.isDarwin;
+  isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
 in
 {
   programs.ghostty = {

--- a/nix/programs/git/default.nix
+++ b/nix/programs/git/default.nix
@@ -103,10 +103,10 @@ in
       gpg = {
         format = "ssh";
       }
-      // (lib.optionalAttrs pkgs.stdenv.isDarwin {
+      // (lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
         ssh.program = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign";
       })
-      // (lib.optionalAttrs pkgs.stdenv.isLinux {
+      // (lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
         ssh.program = "/mnt/c/Program Files/1Password/app/8/op-ssh-sign-wsl";
       });
     };

--- a/nix/programs/herdr/default.nix
+++ b/nix/programs/herdr/default.nix
@@ -8,7 +8,7 @@
 { pkgs, lib, ... }:
 let
   # macOS だけ brew 管理。この分岐が `package` と onChange の両方を決める。
-  useBrew = pkgs.stdenv.isDarwin;
+  useBrew = pkgs.stdenv.hostPlatform.isDarwin;
 
   # activation から herdr を呼ぶための絶対パス。PATH に頼れない事情は下の
   # `onChange` のコメントを参照。

--- a/nix/programs/wezterm/default.nix
+++ b/nix/programs/wezterm/default.nix
@@ -3,7 +3,7 @@
   programs.wezterm = {
     # On darwin wezterm comes from the Homebrew cask, so only pull the nixpkgs
     # build on other platforms.
-    enable = !pkgs.stdenv.isDarwin;
+    enable = !pkgs.stdenv.hostPlatform.isDarwin;
   };
 
   # Mutable (out-of-store) symlink: edited in place, no rebuild required.


### PR DESCRIPTION
## Summary

nixpkgs deprecated the `stdenv.is*` aliases on 2026-05-09
(`pkgs/stdenv/generic/default.nix`, behind `config.allowAliases`), so every
`pkgs.stdenv.isDarwin` / `pkgs.stdenv.isLinux` read now warns on evaluation:

```
evaluation warning: stdenv.isDarwin is deprecated, use stdenv.hostPlatform.isDarwin instead
evaluation warning: stdenv.isLinux is deprecated, use stdenv.hostPlatform.isLinux instead
```

The attribute value is a thunk, so Nix memoises it and each message is printed
once no matter how many call sites there are. Those two lines were in fact nine
of them, all routed through `stdenv.hostPlatform` here.
`nix/modules/nixpkgs.nix` already did this; this brings the rest of the tree in
line.

The comment at the top of `nix/modules/home/profile-darwin.nix` is rewrapped
because the longer attribute path pushed it past the surrounding width.

## Verification

| Check | Result |
| --- | --- |
| `darwinConfigurations.siraken-mbp` drvPath | `svg3ddjjmzbsj4ydfrs0gql4sxsw6lvm-darwin-system-26.11.4cff07d.drv`, identical before and after |
| Evaluation warnings | 0 across `siraken-mbp`, `siraken-macmini`, `wsl-nixos`, `nixos-vm` and `wsl-ubuntu` |
| `nix fmt` | `0 changed` |

The drvPath being identical means the built system is unchanged, so this is a
pure refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
