### PR TITLE
feat: allowlist specific npx commands in auto mode

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -16,7 +16,20 @@
       "WebFetch(domain:www.xserver.ne.jp)",
       "WebFetch(domain:www.xdomain.ne.jp)",
       "WebFetch(domain:bizmw.jp)",
-      "WebFetch(domain:www.ntt.com)"
+      "WebFetch(domain:www.ntt.com)",
+      "Bash(npx vitest:*)",
+      "Bash(npx prettier:*)",
+      "Bash(npx eslint:*)",
+      "Bash(npx biome:*)",
+      "Bash(npx tsc:*)",
+      "Bash(npx svelte-check:*)",
+      "Bash(npx playwright:*)",
+      "Bash(npx vite:*)",
+      "Bash(npx svelte-kit:*)",
+      "Bash(npx wrangler dev:*)",
+      "Bash(npx wrangler types:*)",
+      "Bash(npx wrangler tail:*)",
+      "Bash(npx wrangler whoami:*)"
     ],
     "deny": [
       "Read(id_rsa)",
@@ -40,7 +53,6 @@
       "Bash(rm -rf:*)",
       "Bash(curl:*)",
       "Bash(wget:*)",
-      "Bash(npx:*)",
       "Bash(bunx:*)",
       "Bash(pnpx:*)",
       "Bash(pnpm dlx:*)",
@@ -100,5 +112,11 @@
   "statusLine": {
     "type": "command",
     "command": "/Users/siraken/.claude/xirp-statusline-wrapper.sh"
+  },
+  "autoMode": {
+    "soft_deny": [
+      "$defaults",
+      "Untrusted Package Runner [named+specifics — **must name:** the runner and the package it executes]: Fetching and executing a package through a package runner — `npx` including its `-y` / `--yes` / `--package=<pkg>` forms, `npm exec`, `npm init <pkg>`, `npm create <pkg>`, `bunx`, `bun x`, `bun create`, `pnpm dlx`, `pnpx`, `pnpm create`, `yarn dlx`, `yarn create`, `uvx`, `uv tool run`, `uv run --with <pkg>`, `pipx run`, `deno run` against a remote URL, `composer create-project`, and equivalent fetch-and-execute runners. The blanket coverage is deliberate: the user keeps a short allowlist of vetted runner invocations as `permissions.allow` rules, and the harness resolves those before this classifier is consulted, so a runner invocation that reaches this rule is by construction one the user has not vetted. The package name is the entire security boundary, and a familiar-looking name is not evidence the package is the one it appears to be. The built-in Declared Dependencies exception covers installs that read a manifest, such as `npm install` or `composer install`; it does not name fetch-and-execute runner invocations, so it does not reach this rule's territory — presence in package.json is not the bar here, having been allowlisted is. This rule governs runner invocations specifically and is narrower than the general external-code rules. Clears when the user's own message names the package to run, such as \"run npx create-next-app@latest my-app\" or \"use npx shadcn add button\". Does not apply to `npx --no-install <bin>` or `npx --offline <bin>`, which cannot reach the registry."
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Switch `npx` from a blanket `ask` rule to an allowlist, so vetted invocations run
without a prompt while everything else is stopped by the auto mode classifier.

`Bash(npx:*)` sat in `permissions.ask`, which made per-command exceptions
impossible: Claude Code evaluates rules in the order deny → ask → allow and
ignores specificity, so a narrower `allow` rule never wins over a broader `ask`
one.

> Rules are evaluated in order: deny, then ask, then allow. The first match in
> that order determines the outcome, and rule specificity doesn't change the
> order.
>
> The same precedence applies between ask and allow: a matching ask rule prompts
> even when a more specific allow rule also matches the same call.

— [Configure permissions](https://code.claude.com/docs/en/permissions)

## How it works

Two gates:

1. **`permissions.allow`** — narrow allow rules are resolved before the auto mode
   classifier runs, so allowlisted invocations never reach it and stay
   prompt-free.
2. **`autoMode.soft_deny`** — only invocations that miss the allowlist reach the
   classifier, where the new rule blocks them.

The classifier rule names the sibling runners too (`npm exec`, `npm create`,
`bunx`, `bun x`, `pnpm dlx`, `yarn create`, `uvx`, `uv tool run`, `pipx run`,
`composer create-project`), and exempts `npx --no-install` / `--offline`, which
cannot reach the registry. It is `soft_deny` rather than `hard_deny`, so a
request that names the package ("run `npx create-next-app@latest my-app`") still
clears it. `"$defaults"` keeps the built-in rules in place.

## What is allowed

Picked from actual usage in shell history and past sessions:

| Command | Uses |
| --- | --- |
| `npx vitest` | 37 |
| `npx prettier` | 29 |
| `npx svelte-check` | 26 |
| `npx eslint` | 17 |
| `npx playwright` | 16 |
| `npx tsc`, `npx svelte-kit`, `npx biome`, `npx vite` | 1–2 each |

`wrangler` is limited to `dev` / `types` / `tail` / `whoami`; `deploy` is
deliberately left out.

## Verification

- `claude auto-mode config` shows the rule in the effective config
  (`soft_deny`: 68 = 67 built-in + 1).
- `claude auto-mode critique` was run three times and its findings folded in:
  dropped the unverifiable "is it declared in package.json" test, reworded the
  Declared Dependencies overlap as scoping rather than overriding a mandatory
  exception, and added the missing sibling runners.
- `npx prettier --version` runs without a prompt.

Not yet verified in practice: that a non-allowlisted `npx` is actually blocked. A
session started before this change may still be holding the old `autoMode`
config, so this needs a check in a fresh session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
